### PR TITLE
Restore dedicated Google Play API credentials

### DIFF
--- a/server/services/googlePlayBillingService.js
+++ b/server/services/googlePlayBillingService.js
@@ -38,12 +38,26 @@ function getPackageName() {
   return packageName;
 }
 
+function getGooglePlayCredentialsPath() {
+  const credentialsPath =
+    process.env.GOOGLE_PLAY_APPLICATION_CREDENTIALS?.trim();
+
+  if (!credentialsPath) {
+    throw new Error(
+      'GOOGLE_PLAY_APPLICATION_CREDENTIALS is not configured.'
+    );
+  }
+
+  return credentialsPath;
+}
+
 function getAndroidPublisherClient() {
   if (androidPublisherClient) {
     return androidPublisherClient;
   }
 
   const auth = new google.auth.GoogleAuth({
+    keyFilename: getGooglePlayCredentialsPath(),
     scopes: [ANDROID_PUBLISHER_SCOPE],
   });
 


### PR DESCRIPTION
## Summary

- Restores the dedicated Google Play service-account credential file
- Prevents Google Play verification from using the Firebase Admin service account
- Uses GOOGLE_PLAY_APPLICATION_CREDENTIALS for Android Publisher API calls

## Tests

- billing.test.js: 18 passing
- billing-webhook.test.js: 5 passing
- Total: 23 passing