### PR TITLE
Fix Android Google Play subscription migration

### DIFF
--- a/server/__tests__/billing.test.js
+++ b/server/__tests__/billing.test.js
@@ -10,6 +10,21 @@ let stripeMock;
 let billingRouter;
 let recomputeUserAppEntitlementMock;
 let assertAppSubscriptionProviderAvailableMock;
+let verifyAndApplyGooglePlaySubscriptionMock;
+
+await jest.unstable_mockModule(
+  '../services/googlePlayEntitlementService.js',
+  () => {
+    verifyAndApplyGooglePlaySubscriptionMock =
+      jest.fn();
+
+    return {
+      __esModule: true,
+      verifyAndApplyGooglePlaySubscription:
+        verifyAndApplyGooglePlaySubscriptionMock,
+    };
+  }
+);
 
 beforeAll(async () => {
   process.env.NODE_ENV = 'test';
@@ -29,6 +44,7 @@ beforeAll(async () => {
         },
 
         appSubscription: {
+          findFirst: jest.fn(),
           updateMany: jest.fn(),
         },
 
@@ -102,6 +118,20 @@ beforeAll(async () => {
     }
   );
 
+  await jest.unstable_mockModule(
+    '../services/googlePlayEntitlementService.js',
+    () => {
+      verifyAndApplyGooglePlaySubscriptionMock =
+        jest.fn();
+
+      return {
+        __esModule: true,
+        verifyAndApplyGooglePlaySubscription:
+          verifyAndApplyGooglePlaySubscriptionMock,
+      };
+    }
+  );
+
   ({ default: billingRouter } =
     await import('../routes/billing.js'));
 });
@@ -115,6 +145,9 @@ beforeEach(() => {
 
   recomputeUserAppEntitlementMock
     .mockReset();
+
+  verifyAndApplyGooglePlaySubscriptionMock
+  .mockReset();
 });
 
 function buildApp(userOverride = {}) {
@@ -658,6 +691,195 @@ describe('POST /billing/portal', () => {
     });
   });
 });
+
+describe(
+  'POST /billing/google-play/verify provider migration',
+  () => {
+    test(
+      'explicit restore migrates Stripe app subscription to Google Play',
+      async () => {
+        const app = buildApp();
+
+        const expiryTime =
+          new Date(
+            '2026-08-15T00:00:00.000Z'
+          );
+
+        const conflict =
+          new Error(
+            'This Chatforia app subscription is already managed through STRIPE.'
+          );
+
+        conflict.statusCode = 409;
+        conflict.code =
+          'APP_SUBSCRIPTION_PROVIDER_CONFLICT';
+        conflict.currentProvider =
+          'STRIPE';
+
+        verifyAndApplyGooglePlaySubscriptionMock
+          .mockRejectedValueOnce(
+            conflict
+          )
+          .mockResolvedValueOnce({
+            user: {
+              plan: 'PLUS',
+            },
+
+            verified: {
+              entitlementPlan:
+                'PLUS',
+
+              subscriptionState:
+                'SUBSCRIPTION_STATE_ACTIVE',
+
+              expiryTime,
+
+              productId:
+                'chatforia_plus',
+
+              basePlanId:
+                'monthly',
+
+              autoRenewEnabled:
+                true,
+
+              grantsAccess:
+                true,
+            },
+
+            acknowledged:
+              true,
+
+            acknowledgementPending:
+              false,
+          });
+
+        prismaMock.appSubscription.findFirst
+          .mockResolvedValue({
+            providerSubscriptionKey:
+              'sub_123',
+          });
+
+        stripeMock.subscriptions.cancel
+          .mockResolvedValue({
+            id: 'sub_123',
+            status: 'canceled',
+            livemode: false,
+          });
+
+        prismaMock.appSubscription.updateMany
+          .mockResolvedValue({
+            count: 1,
+          });
+
+        recomputeUserAppEntitlementMock
+          .mockResolvedValue({
+            user: {
+              id: 1,
+              plan: 'FREE',
+              subscriptionStatus:
+                'INACTIVE',
+              subscriptionEndsAt:
+                null,
+              billingProvider:
+                null,
+              billingSubscriptionId:
+                null,
+            },
+          });
+
+        const res =
+          await request(app)
+            .post(
+              '/billing/google-play/verify'
+            )
+            .send({
+              purchaseToken:
+                'google-token-123',
+
+              allowProviderMigration:
+                true,
+            });
+
+        expect(res.statusCode)
+          .toBe(200);
+
+        expect(
+          verifyAndApplyGooglePlaySubscriptionMock
+        ).toHaveBeenCalledTimes(2);
+
+        expect(
+          stripeMock.subscriptions.cancel
+        ).toHaveBeenCalledWith(
+          'sub_123'
+        );
+
+        expect(
+          prismaMock.appSubscription.updateMany
+        ).toHaveBeenCalledWith({
+          where: {
+            userId: 1,
+            provider: 'STRIPE',
+            providerSubscriptionKey:
+              'sub_123',
+          },
+
+          data: {
+            status: 'CANCELED',
+            grantsAccess: false,
+            autoRenewEnabled: false,
+            endsAt:
+              expect.any(Date),
+            lastVerifiedAt:
+              expect.any(Date),
+
+            rawResponse: {
+              source:
+                'google-play-provider-migration',
+
+              migratedTo:
+                'GOOGLE_PLAY',
+
+              livemode:
+                false,
+            },
+          },
+        });
+
+        expect(res.body).toEqual({
+          ok: true,
+          plan: 'PLUS',
+          entitlementPlan:
+            'PLUS',
+
+          status:
+            'SUBSCRIPTION_STATE_ACTIVE',
+
+          expiresAt:
+            expiryTime.toISOString(),
+
+          acknowledged:
+            true,
+
+          acknowledgementPending:
+            false,
+
+          productId:
+            'chatforia_plus',
+
+          basePlanId:
+            'monthly',
+
+          autoRenewEnabled:
+            true,
+
+          grantsAccess:
+            true,
+        });
+      }
+    );
+  }
+);
 
 describe('POST /billing/provider-aware management', () => {
   test('returns Google Play management action instead of opening Stripe portal', async () => {

--- a/server/routes/billing.js
+++ b/server/routes/billing.js
@@ -176,6 +176,110 @@ function planLabel(code) {
   }
 }
 
+async function migrateStripeAppSubscriptionToGooglePlay(
+  userId
+) {
+  const normalizedUserId = Number(userId);
+  const now = new Date();
+
+  const stripeEntitlement =
+    await prisma.appSubscription.findFirst({
+      where: {
+        userId: normalizedUserId,
+        provider: 'STRIPE',
+        grantsAccess: true,
+        plan: {
+          in: ['PLUS', 'PREMIUM'],
+        },
+        AND: [
+          {
+            OR: [
+              { startsAt: null },
+              { startsAt: { lte: now } },
+            ],
+          },
+          {
+            OR: [
+              { endsAt: null },
+              { endsAt: { gt: now } },
+            ],
+          },
+        ],
+      },
+      orderBy: [
+        { endsAt: 'desc' },
+        { updatedAt: 'desc' },
+      ],
+      select: {
+        providerSubscriptionKey: true,
+      },
+    });
+
+  const stripeSubscriptionId =
+    stripeEntitlement?.providerSubscriptionKey;
+
+  if (!stripeSubscriptionId) {
+    const error = new Error(
+      'No active Stripe app subscription was found to migrate.'
+    );
+
+    error.statusCode = 409;
+    error.code = 'NO_STRIPE_APP_SUBSCRIPTION';
+
+    throw error;
+  }
+
+  // Cancel the actual Stripe app subscription first.
+  // This does not affect wireless/eSIM purchases.
+  const canceledSubscription =
+    await stripe.subscriptions.cancel(
+      stripeSubscriptionId
+    );
+
+  const entitlementResult =
+    await prisma.$transaction(async (tx) => {
+      await tx.appSubscription.updateMany({
+        where: {
+          userId: normalizedUserId,
+          provider: 'STRIPE',
+          providerSubscriptionKey:
+            stripeSubscriptionId,
+        },
+        data: {
+          status: String(
+            canceledSubscription?.status ||
+              'canceled'
+          ).toUpperCase(),
+          grantsAccess: false,
+          autoRenewEnabled: false,
+          endsAt: now,
+          lastVerifiedAt: now,
+          rawResponse: {
+            source:
+              'google-play-provider-migration',
+            migratedTo: 'GOOGLE_PLAY',
+            livemode: Boolean(
+              canceledSubscription?.livemode
+            ),
+          },
+        },
+      });
+
+      return recomputeUserAppEntitlement(
+        normalizedUserId,
+        {
+          db: tx,
+          now,
+        }
+      );
+    });
+
+  return {
+    stripeSubscriptionId,
+    entitlementResult,
+  };
+}
+
 router.get('/my-plan', async (req, res) => {
   try {
     const userId = req.user?.id ? Number(req.user.id) : null;
@@ -797,12 +901,41 @@ router.post('/google-play/verify', async (req, res) => {
     });
   }
 
-  try {
-    const result =
-      await verifyAndApplyGooglePlaySubscription({
-        userId: req.user.id,
-        purchaseToken,
-      });
+  const allowProviderMigration =
+    req.body?.allowProviderMigration === true;
+
+    try {
+      let result;
+
+      try {
+        result =
+          await verifyAndApplyGooglePlaySubscription({
+            userId: req.user.id,
+            purchaseToken,
+          });
+      } catch (error) {
+        const canMigrateFromStripe =
+          allowProviderMigration &&
+          error?.code ===
+            'APP_SUBSCRIPTION_PROVIDER_CONFLICT' &&
+          error?.currentProvider === 'STRIPE';
+
+        if (!canMigrateFromStripe) {
+          throw error;
+        }
+
+        await migrateStripeAppSubscriptionToGooglePlay(
+          req.user.id
+        );
+
+        // The valid Google purchase can now become the
+        // authoritative app entitlement.
+        result =
+          await verifyAndApplyGooglePlaySubscription({
+            userId: req.user.id,
+            purchaseToken,
+          });
+      }
 
     return res.json({
       ok: true,


### PR DESCRIPTION
## Summary

- Allows an explicit Android Google Play purchase or Restore Purchases action to migrate an existing Stripe app subscription to Google Play.
- Cancels only the Stripe Plus/Premium app subscription.
- Leaves Chatforia Wireless, eSIM, and data-pack Stripe purchases untouched.
- Retries Google Play verification after the Stripe app entitlement is deactivated.
- Preserves provider-conflict protection for Apple, Manual, and non-explicit requests.

## Testing

- Android Kotlin compilation passed.
- Billing and billing-webhook suites passed: 24/24 tests.
- Added coverage for explicit Stripe-to-Google Play migration.