### PR TITLE
fix: support sandbox eSIM activation

### DIFF
--- a/server/controllers/esimController.js
+++ b/server/controllers/esimController.js
@@ -200,54 +200,151 @@ export async function activateProfile(req, res) {
         .json({ error: 'activateProfile not implemented' });
     }
 
-    const iccid = String(req.body?.iccid || '').trim();
-    const activationCode = String(req.body?.code || req.body?.activationCode || '').trim();
-    const providerProfileId = String(req.body?.providerProfileId || '').trim();
+    const userId = req.user?.id ?? null;
+
+    if (!userId) {
+      return res.status(401).json({
+        error: 'Not authenticated',
+      });
+    }
+
+    const iccid =
+      String(req.body?.iccid || '').trim();
+
+    const activationCode =
+      String(
+        req.body?.code ||
+        req.body?.activationCode ||
+        ''
+      ).trim();
+
+    const providerProfileId =
+      String(
+        req.body?.providerProfileId || ''
+      ).trim();
 
     if (!iccid && !activationCode && !providerProfileId) {
       return res.status(400).json({
-        error: 'providerProfileId, iccid, or activationCode is required',
+        error:
+          'providerProfileId, iccid, or activationCode is required',
       });
     }
 
-    const out = await esimProvider.activateProfile({
-      iccid: iccid || undefined,
-      activationCode: activationCode || undefined,
-      providerProfileId: providerProfileId || undefined,
-    });
+    const identifierFilters = [
+      providerProfileId
+        ? { providerProfileId }
+        : undefined,
 
-    const userId = req.user?.id ?? null;
+      iccid
+        ? { iccid }
+        : undefined,
 
-    if (userId) {
-      const existing = await prisma.subscriber.findFirst({
+      activationCode
+        ? { activationCode }
+        : undefined,
+    ].filter(Boolean);
+
+    const existing =
+      await prisma.subscriber.findFirst({
         where: {
           userId: Number(userId),
-          OR: [
-            providerProfileId ? { providerProfileId } : undefined,
-            iccid ? { iccid } : undefined,
-            activationCode ? { activationCode } : undefined,
-          ].filter(Boolean),
+          OR: identifierFilters,
         },
-        orderBy: { createdAt: 'desc' },
+        orderBy: {
+          createdAt: 'desc',
+        },
       });
 
-      if (existing) {
-        await prisma.subscriber.update({
-          where: { id: existing.id },
-          data: {
-            status: 'ACTIVE',
-            activatedAt: out?.activatedAt ? new Date(out.activatedAt) : new Date(),
-            msisdn: out?.msisdn || existing.msisdn || null,
-            providerMeta: out || undefined,
-          },
-        });
-      }
+    if (!existing) {
+      return res.status(404).json({
+        error: 'eSIM profile not found',
+      });
     }
 
-    return res.json({ ok: true, ...out });
+    const existingProviderMeta =
+      existing.providerMeta &&
+      typeof existing.providerMeta === 'object' &&
+      !Array.isArray(existing.providerMeta)
+        ? existing.providerMeta
+        : {};
+
+    // Sandbox mode is determined from the saved server record,
+    // never from a client-supplied test flag.
+    const testMode =
+      String(
+        existing.providerProfileId || ''
+      ).startsWith('mock-telna-') ||
+
+      existingProviderMeta?.reserve
+        ?.providerMeta?.mock === true ||
+
+      existingProviderMeta?.providerPack
+        ?.providerMeta?.mock === true;
+
+    const out =
+      await esimProvider.activateProfile({
+        iccid:
+          existing.iccid ||
+          iccid ||
+          undefined,
+
+        activationCode:
+          existing.activationCode ||
+          activationCode ||
+          undefined,
+
+        providerProfileId:
+          existing.providerProfileId ||
+          providerProfileId ||
+          undefined,
+
+        testMode,
+      });
+
+    const activatedAt =
+      out?.activatedAt
+        ? new Date(out.activatedAt)
+        : new Date();
+
+    const updatedSubscriber =
+      await prisma.subscriber.update({
+        where: {
+          id: existing.id,
+        },
+        data: {
+          status: 'ACTIVE',
+          activatedAt,
+
+          msisdn:
+            out?.msisdn ||
+            existing.msisdn ||
+            null,
+
+          // Preserve reservation and provisioning metadata.
+          providerMeta: {
+            ...existingProviderMeta,
+            activation: {
+              ...out,
+              testMode,
+            },
+          },
+        },
+      });
+
+    return res.json({
+      ok: true,
+      ...out,
+      status: updatedSubscriber.status,
+    });
   } catch (err) {
-    console.error('[esim] activateProfile error:', err);
-    return res.status(500).json({ error: 'Failed to activate eSIM profile' });
+    console.error(
+      '[esim] activateProfile error:',
+      err
+    );
+
+    return res.status(500).json({
+      error: 'Failed to activate eSIM profile',
+    });
   }
 }
 

--- a/server/services/providers/telnaEsim.js
+++ b/server/services/providers/telnaEsim.js
@@ -92,14 +92,43 @@ if (testMode || process.env.ESIM_MOCK === 'true') {
  * params: { providerProfileId?, iccid?, activationCode? }
  * returns: { ok: boolean, activatedAt?: Date, msisdn?: string|null, providerMeta?: object }
  */
-export async function activateProfile({ providerProfileId, iccid, activationCode } = {}) {
-  ensureConfigured();
-
+export async function activateProfile({
+  providerProfileId,
+  iccid,
+  activationCode,
+  testMode = false,
+} = {}) {
   if (!providerProfileId && !iccid && !activationCode) {
-    const err = new Error('activateProfile requires providerProfileId, iccid, or activationCode');
+    const err = new Error(
+      'activateProfile requires providerProfileId, iccid, or activationCode'
+    );
+
     err.code = 'TELNA_MISSING_ACTIVATION_IDENTIFIERS';
     throw err;
   }
+
+  const useMock =
+    testMode === true ||
+    process.env.ESIM_MOCK === 'true';
+
+  if (useMock) {
+    const activatedAt = new Date();
+
+    return {
+      ok: true,
+      activatedAt,
+      msisdn: null,
+      providerMeta: {
+        mock: true,
+        testMode: Boolean(testMode),
+        providerProfileId: providerProfileId || null,
+        iccid: iccid || null,
+        activatedAt: activatedAt.toISOString(),
+      },
+    };
+  }
+
+  ensureConfigured();
 
   const payload = {
     profileId: providerProfileId,
@@ -114,18 +143,36 @@ export async function activateProfile({ providerProfileId, iccid, activationCode
     });
 
     const activatedAt =
-      data.activatedAt || data.activated_at || data.activationTimestamp || null;
+      data.activatedAt ||
+      data.activated_at ||
+      data.activationTimestamp ||
+      null;
 
     return {
       ok: Boolean(data.ok ?? data.success ?? true),
-      activatedAt: activatedAt ? new Date(activatedAt) : undefined,
-      msisdn: data.msisdn ?? data.msisdnAssigned ?? null,
+
+      activatedAt: activatedAt
+        ? new Date(activatedAt)
+        : undefined,
+
+      msisdn:
+        data.msisdn ??
+        data.msisdnAssigned ??
+        null,
+
       providerMeta: data ?? null,
     };
   } catch (err) {
-    const wrapped = new Error(`Telna activateProfile failed: ${err.message}`);
-    wrapped.code = err.code || 'TELNA_ACTIVATE_FAILED';
-    wrapped.providerMeta = err.providerBody ?? null;
+    const wrapped = new Error(
+      `Telna activateProfile failed: ${err.message}`
+    );
+
+    wrapped.code =
+      err.code || 'TELNA_ACTIVATE_FAILED';
+
+    wrapped.providerMeta =
+      err.providerBody ?? null;
+
     throw wrapped;
   }
 }


### PR DESCRIPTION
## Summary
- Makes eSIM activation mock-aware for Stripe Sandbox purchases
- Determines sandbox mode from the saved subscriber record
- Prevents mock eSIM profiles from contacting the live Telna API
- Preserves reservation and provisioning metadata when activation succeeds

## Testing
- Node syntax checks passed
- Direct mock activation returned ok: true
- Confirmed mock: true and testMode: true
- No TELNA_NOT_CONFIGURED error