### PR TITLE
Fix eSIM top-ups and iOS checkout returns

### DIFF
--- a/client/public/.well-known/apple-app-site-association
+++ b/client/public/.well-known/apple-app-site-association
@@ -1,0 +1,14 @@
+{
+  "applinks": {
+    "apps": [],
+    "details": [
+      {
+        "appID": "975B563V2R.com.chatforia.Chatforia",
+        "paths": [
+          "/mobile/esim/checkout-complete*",
+          "/mobile/esim/checkout-canceled*"
+        ]
+      }
+    ]
+  }
+}

--- a/client/src/AppRoutes.jsx
+++ b/client/src/AppRoutes.jsx
@@ -24,6 +24,7 @@ const SettingsBackups = lazy(() => import('@/pages/SettingsBackups.jsx'));
 import UpgradePage from '@/pages/UpgradePlan';
 import UpgradeSuccess from '@/pages/UpgradeSuccess.jsx';
 import BillingReturn from '@/pages/BillingReturn.jsx';
+import MobileEsimCheckoutReturn from '@/pages/MobileEsimCheckoutReturn.jsx';
 import Sidebar from '@/components/Sidebar';
 import RandomChatPage from '@/pages/RandomChatPage.jsx';
 import LoginForm from '@/components/LoginForm';
@@ -351,6 +352,19 @@ export default function AppRoutes() {
         <Route path="/upgrade" element={<UpgradePage variant="account" />} />
         <Route path="/pricing" element={<UpgradePage variant="public" />} />
 
+        <Route
+          path="/mobile/esim/checkout-complete"
+          element={
+            <MobileEsimCheckoutReturn status="complete" />
+          }
+        />
+        <Route
+          path="/mobile/esim/checkout-canceled"
+          element={
+            <MobileEsimCheckoutReturn status="canceled" />
+          }
+        />
+
         {/* Auth + marketing layout */}
         <Route element={<AuthLayout />}>
           <Route path="/" element={<LoginForm />} />
@@ -402,6 +416,19 @@ export default function AppRoutes() {
     <>
       <AdSenseAutoAds />
     <Routes>
+      <Route
+        path="/mobile/esim/checkout-complete"
+        element={
+          <MobileEsimCheckoutReturn status="complete" />
+        }
+      />
+      <Route
+        path="/mobile/esim/checkout-canceled"
+        element={
+          <MobileEsimCheckoutReturn status="canceled" />
+        }
+      />
+
       <Route path="/upgrade" element={<UpgradePage variant="account" />} />
       <Route path="/pricing" element={<Navigate to="/upgrade" replace />} />
       <Route path="/upgrade/success" element={<UpgradeSuccess />} />

--- a/client/src/pages/MobileEsimCheckoutReturn.jsx
+++ b/client/src/pages/MobileEsimCheckoutReturn.jsx
@@ -1,0 +1,78 @@
+import {
+  Button,
+  Container,
+  Paper,
+  Stack,
+  Text,
+  Title,
+} from '@mantine/core';
+import {
+  Link,
+  useSearchParams,
+} from 'react-router-dom';
+
+export default function MobileEsimCheckoutReturn({
+  status,
+}) {
+  const [searchParams] = useSearchParams();
+
+  const completed = status === 'complete';
+  const sessionId =
+    searchParams.get('session_id') || '';
+
+  const appURL = new URL(
+    completed
+      ? 'chatforia://checkout/esim/complete'
+      : 'chatforia://checkout/esim/canceled'
+  );
+
+  if (sessionId) {
+    appURL.searchParams.set(
+      'session_id',
+      sessionId
+    );
+  }
+
+  return (
+    <Container size="xs" py={80}>
+      <Paper
+        withBorder
+        radius="xl"
+        p="xl"
+        shadow="sm"
+      >
+        <Stack gap="lg">
+          <Title order={2}>
+            {completed
+              ? 'Your data pack was added'
+              : 'Checkout canceled'}
+          </Title>
+
+          <Text c="dimmed">
+            {completed
+              ? 'Return to Chatforia to see your updated eSIM balance.'
+              : 'No new data pack was added.'}
+          </Text>
+
+          <Button
+            component="a"
+            href={appURL.toString()}
+            size="lg"
+            fullWidth
+          >
+            Open Chatforia
+          </Button>
+
+          <Button
+            component={Link}
+            to="/"
+            variant="subtle"
+            fullWidth
+          >
+            Continue on the website
+          </Button>
+        </Stack>
+      </Paper>
+    </Container>
+  );
+}

--- a/server/__tests__/billing-webhook.test.js
+++ b/server/__tests__/billing-webhook.test.js
@@ -210,6 +210,18 @@ describe(
     },
   });
 
+  await prisma.subscriber.deleteMany({
+    where: {
+      userId: TEST_USER_ID,
+    },
+  });
+
+  await prisma.mobileDataPackPurchase.deleteMany({
+    where: {
+      userId: TEST_USER_ID,
+    },
+  });
+
   await prisma.user.deleteMany({
     where: {
       id: TEST_USER_ID,
@@ -292,6 +304,262 @@ describe(
         ).toBe(
           'checkout.session.completed'
         );
+      }
+    );
+
+    test(
+      'Sandbox eSIM top-up carries forward balance exactly once',
+      async () => {
+        await createTestUser();
+
+        const priorPurchasedAt =
+          new Date(
+            Date.now() -
+              24 * 60 * 60 * 1000
+          );
+
+        const priorExpiresAt =
+          new Date(
+            Date.now() +
+              20 *
+                24 *
+                60 *
+                60 *
+                1000
+          );
+
+        const priorPurchase =
+          await prisma.mobileDataPackPurchase.create({
+            data: {
+              userId: TEST_USER_ID,
+              kind: 'ESIM',
+              addonKind:
+                'chatforia_esim_local_3_premium',
+              purchasedAt:
+                priorPurchasedAt,
+              expiresAt:
+                priorExpiresAt,
+              totalDataMb:
+                3 * 1024,
+              remainingDataMb:
+                2 * 1024,
+              billingTransactionId:
+                'pi_existing_local_3',
+              esimProfileId:
+                'mock-telna-existing',
+              iccid:
+                '89000000000000999',
+            },
+          });
+
+        const subscriber =
+          await prisma.subscriber.create({
+            data: {
+              userId: TEST_USER_ID,
+              purchaseId:
+                priorPurchase.id,
+              provider: 'telna',
+              providerProfileId:
+                'mock-telna-existing',
+              iccid:
+                '89000000000000999',
+              iccidHint:
+                '890000••••••',
+              region: 'US',
+              status: 'ACTIVE',
+              activatedAt:
+                priorPurchasedAt,
+              expiresAt:
+                priorExpiresAt,
+              providerMeta: {
+                mock: true,
+              },
+            },
+          });
+
+        const checkoutSession = {
+          object:
+            'checkout.session',
+          id:
+            'cs_esim_topup_local_5',
+          mode:
+            'payment',
+          status:
+            'complete',
+          payment_status:
+            'paid',
+          payment_intent:
+            'pi_esim_topup_local_5',
+          client_reference_id:
+            String(TEST_USER_ID),
+          livemode:
+            false,
+
+          metadata: {
+            userId:
+              String(TEST_USER_ID),
+            product:
+              'chatforia_esim_local_5',
+            platform:
+              'ios',
+          },
+        };
+
+        const postWebhook = (event) =>
+          agent
+            .post(
+              ENDPOINTS.webhook
+            )
+            .set(
+              'Stripe-Signature',
+              't=0,v1=testsig'
+            )
+            .set(
+              'Content-Type',
+              'application/json'
+            )
+            .send(
+              JSON.stringify(event)
+            );
+
+        const firstEvent =
+          makeStripeEvent({
+            id:
+              'evt_esim_topup_local_5',
+            type:
+              'checkout.session.completed',
+            object:
+              checkoutSession,
+          });
+
+        await postWebhook(
+          firstEvent
+        ).expect(200);
+
+        const topUpPurchase =
+          await prisma.mobileDataPackPurchase.findUnique({
+            where: {
+              billingTransactionId:
+                'pi_esim_topup_local_5',
+            },
+          });
+
+        expect(
+          topUpPurchase
+        ).toEqual(
+          expect.objectContaining({
+            userId:
+              TEST_USER_ID,
+            totalDataMb:
+              8 * 1024,
+            remainingDataMb:
+              7 * 1024,
+            esimProfileId:
+              'mock-telna-existing',
+          })
+        );
+
+        const transferredPrior =
+          await prisma.mobileDataPackPurchase.findUnique({
+            where: {
+              id:
+                priorPurchase.id,
+            },
+          });
+
+        expect(
+          transferredPrior.remainingDataMb
+        ).toBe(0);
+
+        const updatedSubscriber =
+          await prisma.subscriber.findUnique({
+            where: {
+              id:
+                subscriber.id,
+            },
+          });
+
+        expect(
+          updatedSubscriber
+        ).toEqual(
+          expect.objectContaining({
+            purchaseId:
+              topUpPurchase.id,
+            providerProfileId:
+              'mock-telna-existing',
+          })
+        );
+
+        expect(
+          updatedSubscriber
+            .providerMeta
+            .topUp
+        ).toEqual(
+          expect.objectContaining({
+            previousPurchaseId:
+              priorPurchase.id,
+            carriedTotalDataMb:
+              3 * 1024,
+            carriedRemainingDataMb:
+              2 * 1024,
+            creditedDataMb:
+              5 * 1024,
+            combinedTotalDataMb:
+              8 * 1024,
+            combinedRemainingDataMb:
+              7 * 1024,
+            sandbox:
+              true,
+          })
+        );
+
+        // Simulate Stripe delivering the same
+        // checkout under another event ID.
+        const retryEvent =
+          makeStripeEvent({
+            id:
+              'evt_esim_topup_local_5_retry',
+            type:
+              'checkout.session.completed',
+            object:
+              checkoutSession,
+          });
+
+        await postWebhook(
+          retryEvent
+        ).expect(200);
+
+        const purchaseAfterRetry =
+          await prisma.mobileDataPackPurchase.findUnique({
+            where: {
+              billingTransactionId:
+                'pi_esim_topup_local_5',
+            },
+          });
+
+        expect(
+          purchaseAfterRetry.totalDataMb
+        ).toBe(
+          8 * 1024
+        );
+
+        expect(
+          purchaseAfterRetry.remainingDataMb
+        ).toBe(
+          7 * 1024
+        );
+
+        const purchaseCount =
+          await prisma.mobileDataPackPurchase.count({
+            where: {
+              userId:
+                TEST_USER_ID,
+            },
+          });
+
+        expect(
+          purchaseCount
+        ).toBe(2);
       }
     );
 

--- a/server/__tests__/billing.test.js
+++ b/server/__tests__/billing.test.js
@@ -33,6 +33,7 @@ beforeAll(async () => {
   process.env.STRIPE_PRICE_PLUS_MONTHLY = 'price_plus';
   process.env.STRIPE_PRICE_PREMIUM_MONTHLY = 'price_prem_m';
   process.env.STRIPE_PRICE_PREMIUM_ANNUAL = 'price_prem_a';
+  process.env.STRIPE_PRICE_ESIM_LOCAL_5 = 'price_esim_local_5';
 
   await jest.unstable_mockModule(
     '../utils/prismaClient.js',
@@ -598,6 +599,78 @@ describe('POST /billing/checkout', () => {
     stripeMock.checkout.sessions.create
   ).not.toHaveBeenCalled();
 });
+
+  test(
+    'creates iOS eSIM checkout with mobile return URLs',
+    async () => {
+      const app = buildApp();
+
+      prismaMock.user.findUnique.mockResolvedValue({
+        id: 1,
+        email: 'user@test.com',
+        username: 'julian',
+        plan: 'FREE',
+        billingProvider: null,
+        billingCustomerId: 'cus_123',
+        billingSubscriptionId: null,
+        subscriptionStatus: 'INACTIVE',
+        subscriptionEndsAt: null,
+      });
+
+      stripeMock.checkout.sessions.create.mockResolvedValue({
+        id: 'cs_esim_ios_123',
+        url: 'https://stripe.test/checkout/cs_esim_ios_123',
+      });
+
+      const res = await request(app)
+        .post('/billing/checkout')
+        .send({
+          product: 'chatforia_esim_local_5',
+          platform: 'ios',
+        });
+
+      expect(res.statusCode).toBe(200);
+
+      expect(
+        stripeMock.checkout.sessions.create
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({
+          mode: 'payment',
+
+          line_items: [
+            {
+              price: 'price_esim_local_5',
+              quantity: 1,
+            },
+          ],
+
+          metadata: expect.objectContaining({
+            userId: '1',
+            product: 'chatforia_esim_local_5',
+            addonKind:
+              'chatforia_esim_local_5_premium',
+            addonType: 'ESIM',
+            checkoutType: 'payment',
+            platform: 'ios',
+          }),
+
+          success_url:
+            'https://app.test/mobile/esim/checkout-complete?session_id={CHECKOUT_SESSION_ID}',
+
+          cancel_url:
+            'https://app.test/mobile/esim/checkout-canceled',
+        })
+      );
+
+      expect(res.body).toEqual(
+        expect.objectContaining({
+          checkoutUrl:
+            'https://stripe.test/checkout/cs_esim_ios_123',
+          sessionId: 'cs_esim_ios_123',
+        })
+      );
+    }
+  );
 
   test('returns 404 when user is not found', async () => {
     const app = buildApp();

--- a/server/routes/billing.js
+++ b/server/routes/billing.js
@@ -432,6 +432,19 @@ router.post('/checkout', async (req, res) => {
       process.env.WEB_URL ||
       'https://chatforia.com';
 
+    const isIOSAddonCheckout =
+      isAddon && platform === 'ios';
+
+    const addonSuccessURL =
+      isIOSAddonCheckout
+        ? `${frontendOrigin}/mobile/esim/checkout-complete?session_id={CHECKOUT_SESSION_ID}`
+        : `${frontendOrigin}/account/esim?session_id={CHECKOUT_SESSION_ID}`;
+
+    const addonCancelURL =
+      isIOSAddonCheckout
+        ? `${frontendOrigin}/mobile/esim/checkout-canceled`
+        : `${frontendOrigin}/upgrade?canceled=1`;
+
     const effectiveProvider =
       String(user.billingProvider || '')
         .trim()
@@ -552,11 +565,12 @@ router.post('/checkout', async (req, res) => {
       metadata: checkoutMetadata,
 
       success_url: isAddon
-        ? `${frontendOrigin}/account/esim?session_id={CHECKOUT_SESSION_ID}`
+        ? addonSuccessURL
         : `${frontendOrigin}/upgrade-success?session_id={CHECKOUT_SESSION_ID}`,
 
-      cancel_url:
-        `${frontendOrigin}/upgrade?canceled=1`,
+      cancel_url: isAddon
+        ? addonCancelURL
+        : `${frontendOrigin}/upgrade?canceled=1`,
     };
 
     if (!isSubscription) {

--- a/server/routes/billingWebhook.js
+++ b/server/routes/billingWebhook.js
@@ -589,7 +589,19 @@ async function applyPaidAddonCheckoutSession(session) {
 
   const transactionId = String(session.payment_intent || session.id);
   const purchasedAt = new Date();
-  const fallbackExpiresAt = addDays(purchasedAt, addonCfg.daysValid || 30);
+  const fallbackExpiresAt = addDays(
+    purchasedAt,
+    addonCfg.daysValid || 30
+  );
+
+  const purchasedDataMb =
+    Number.isInteger(addonCfg.dataMb) &&
+    addonCfg.dataMb >= 0
+      ? addonCfg.dataMb
+      : 0;
+
+  const isSandboxCheckout =
+    session.livemode === false;
 
   let purchase = await prisma.mobileDataPackPurchase.findFirst({
     where: {
@@ -605,11 +617,54 @@ async function applyPaidAddonCheckoutSession(session) {
         addonKind: addonCfg.addonKind,
         purchasedAt,
         expiresAt: fallbackExpiresAt,
-        totalDataMb: addonCfg.dataMb,
-        remainingDataMb: addonCfg.dataMb,
+        totalDataMb: purchasedDataMb,
+        remainingDataMb: purchasedDataMb,
         billingTransactionId: transactionId,
       },
     });
+  }
+
+  const purchaseAlreadyContainsCarryForward =
+    purchasedDataMb > 0 &&
+    purchase.totalDataMb > purchasedDataMb;
+
+  let carriedBalance = null;
+
+  // Stripe Sandbox uses the mock provider, so preserve any
+  // remaining finite-data balance when another pack is bought.
+  // Live Telna balances remain provider-authoritative.
+  if (
+    isSandboxCheckout &&
+    purchasedDataMb > 0 &&
+    !purchaseAlreadyContainsCarryForward
+  ) {
+    const priorPack =
+      await prisma.mobileDataPackPurchase.findFirst({
+        where: {
+          userId: Number(userId),
+          id: {
+            not: purchase.id,
+          },
+          expiresAt: {
+            gt: purchasedAt,
+          },
+          remainingDataMb: {
+            gt: 0,
+          },
+        },
+        orderBy: {
+          purchasedAt: 'desc',
+        },
+      });
+
+    if (priorPack) {
+      carriedBalance = {
+        purchaseId: priorPack.id,
+        totalDataMb: priorPack.totalDataMb,
+        remainingDataMb:
+          priorPack.remainingDataMb,
+      };
+    }
   }
 
   let subscriber = await getLatestSubscriberForUser(userId);
@@ -626,7 +681,7 @@ async function applyPaidAddonCheckoutSession(session) {
       region,
       addonKind: addonCfg.addonKind,
       planCode: addonCfg.addonKind,
-      testMode: session.livemode === false,
+      testMode: isSandboxCheckout,
     });
 
     providerProfileId = reserve?.providerProfileId || null;
@@ -682,63 +737,136 @@ async function applyPaidAddonCheckoutSession(session) {
       providerProfileId: String(providerProfileId),
       addonKind: addonCfg.addonKind,
       planCode: addonCfg.addonKind,
-      testMode: session.livemode === false,
+      testMode: isSandboxCheckout,
     });
   }
 
-  const nextExpiresAt = providerPack?.expiresAt || fallbackExpiresAt;
-  const nextTotalDataMb =
-    typeof providerPack?.dataMb === 'number' ? providerPack.dataMb : addonCfg.dataMb;
+  const nextExpiresAt =
+    providerPack?.expiresAt || fallbackExpiresAt;
 
-  await prisma.mobileDataPackPurchase.update({
-    where: { id: purchase.id },
-    data: {
-      expiresAt: nextExpiresAt,
-      totalDataMb: nextTotalDataMb,
-      remainingDataMb: nextTotalDataMb,
-      esimProfileId: providerProfileId || purchase.esimProfileId || null,
-      iccid:
-        providerPack?.iccid ||
-        reserve?.iccid ||
-        subscriber?.iccid ||
-        purchase.iccid ||
-        null,
-      qrCodeSvg: providerPack?.qrCodeSvg || purchase.qrCodeSvg || null,
-    },
-  });
+  let nextTotalDataMb =
+    purchaseAlreadyContainsCarryForward
+      ? purchase.totalDataMb
+      : typeof providerPack?.dataMb === 'number'
+        ? providerPack.dataMb
+        : purchasedDataMb;
 
-  if (subscriber?.id) {
-    const nextProviderMeta = {
-      ...(subscriber.providerMeta || {}),
-      stripeSessionId: session.id,
-      stripePaymentIntentId: transactionId,
-      product,
-      addonKind: addonCfg.addonKind,
+  let nextRemainingDataMb =
+    purchaseAlreadyContainsCarryForward
+      ? purchase.remainingDataMb
+      : nextTotalDataMb;
+
+  if (carriedBalance) {
+    nextTotalDataMb =
+      carriedBalance.totalDataMb +
+      purchasedDataMb;
+
+    nextRemainingDataMb =
+      carriedBalance.remainingDataMb +
+      purchasedDataMb;
+  }
+
+  const nextProviderMeta = subscriber?.id
+    ? {
+        ...(subscriber.providerMeta || {}),
+        stripeSessionId: session.id,
+        stripePaymentIntentId: transactionId,
+        product,
+        addonKind: addonCfg.addonKind,
+      }
+    : null;
+
+  if (nextProviderMeta && reserve) {
+    nextProviderMeta.reserve = reserve;
+  }
+
+  if (nextProviderMeta && providerPack) {
+    nextProviderMeta.providerPack =
+      providerPack;
+  }
+
+  if (nextProviderMeta && carriedBalance) {
+    nextProviderMeta.topUp = {
+      previousPurchaseId:
+        carriedBalance.purchaseId,
+      carriedTotalDataMb:
+        carriedBalance.totalDataMb,
+      carriedRemainingDataMb:
+        carriedBalance.remainingDataMb,
+      creditedDataMb:
+        purchasedDataMb,
+      combinedTotalDataMb:
+        nextTotalDataMb,
+      combinedRemainingDataMb:
+        nextRemainingDataMb,
+      appliedAt:
+        new Date().toISOString(),
+      sandbox: true,
     };
+  }
 
-    if (reserve) {
-      nextProviderMeta.reserve = reserve;
+  await prisma.$transaction(async (tx) => {
+    if (carriedBalance) {
+      await tx.mobileDataPackPurchase.update({
+        where: {
+          id: carriedBalance.purchaseId,
+        },
+        data: {
+          // The balance has been transferred into the
+          // newest active purchase record.
+          remainingDataMb: 0,
+        },
+      });
     }
 
-    if (providerPack) {
-      nextProviderMeta.providerPack = providerPack;
-    }
-
-    await prisma.subscriber.update({
-      where: { id: subscriber.id },
+    await tx.mobileDataPackPurchase.update({
+      where: {
+        id: purchase.id,
+      },
       data: {
-        purchaseId: purchase.id,
-        providerProfileId: providerProfileId || subscriber.providerProfileId || null,
+        expiresAt: nextExpiresAt,
+        totalDataMb: nextTotalDataMb,
+        remainingDataMb:
+          nextRemainingDataMb,
+        esimProfileId:
+          providerProfileId ||
+          purchase.esimProfileId ||
+          null,
         iccid:
           providerPack?.iccid ||
           reserve?.iccid ||
-          subscriber.iccid ||
+          subscriber?.iccid ||
+          purchase.iccid ||
           null,
-        expiresAt: nextExpiresAt,
-        providerMeta: nextProviderMeta,
+        qrCodeSvg:
+          providerPack?.qrCodeSvg ||
+          purchase.qrCodeSvg ||
+          null,
       },
     });
-  }
+
+    if (subscriber?.id) {
+      await tx.subscriber.update({
+        where: {
+          id: subscriber.id,
+        },
+        data: {
+          purchaseId: purchase.id,
+          providerProfileId:
+            providerProfileId ||
+            subscriber.providerProfileId ||
+            null,
+          iccid:
+            providerPack?.iccid ||
+            reserve?.iccid ||
+            subscriber.iccid ||
+            null,
+          expiresAt: nextExpiresAt,
+          providerMeta: nextProviderMeta,
+        },
+      });
+    }
+  });
 
   return {
     ignored: false,

--- a/server/routes/wireless.js
+++ b/server/routes/wireless.js
@@ -82,6 +82,15 @@ async function refreshPackUsageFromProvider(userId, pack) {
 
   if (!providerIdentifier) return pack;
 
+  // Sandbox profiles have no real Telna usage endpoint.
+  // Keep using the saved database balance instead.
+  if (
+    String(providerIdentifier)
+      .startsWith('mock-telna-')
+  ) {
+    return pack;
+  }
+
   try {
     const usage = await fetchEsimUsage(providerIdentifier);
 


### PR DESCRIPTION
## Summary

- make finite-data Stripe Sandbox eSIM top-ups additive
- preserve the existing subscriber and eSIM profile
- prevent duplicate webhook delivery from crediting data twice
- stop mock eSIM profiles from attempting Telna usage refreshes
- add iOS-specific Stripe success and cancellation URLs
- add public mobile checkout fallback pages
- publish the Apple app-site association file
- add regression coverage for iOS checkout routing and additive top-ups

## Verification

- production client build completed successfully
- 2 billing test suites passed
- 26 tests passed
- git diff check passed