### PR TITLE
Add eSIM checkout status endpoint

### DIFF
--- a/server/__tests__/billing.test.js
+++ b/server/__tests__/billing.test.js
@@ -49,6 +49,14 @@ beforeAll(async () => {
           updateMany: jest.fn(),
         },
 
+        mobileDataPackPurchase: {
+          findFirst: jest.fn(),
+        },
+
+        subscriber: {
+          findFirst: jest.fn(),
+        },
+
         $transaction: jest.fn(
           async (callback) =>
             callback(prismaMock)
@@ -99,6 +107,7 @@ beforeAll(async () => {
         checkout: {
           sessions: {
             create: jest.fn(),
+            retrieve: jest.fn(),
           },
         },
 
@@ -244,6 +253,221 @@ describe('GET /billing/my-plan', () => {
         status: 'ACTIVE',
         renewsAt: renewsAt.toISOString(),
         provider: 'STRIPE',
+      },
+    });
+  });
+});
+
+describe('GET /billing/checkout-status', () => {
+  const paidEsimSession = {
+    id: 'cs_test_esim_123',
+    mode: 'payment',
+    status: 'complete',
+    payment_status: 'paid',
+    payment_intent:
+      'pi_test_esim_123',
+    client_reference_id: '1',
+    metadata: {
+      userId: '1',
+      product:
+        'chatforia_esim_local_5',
+      addonKind:
+        'chatforia_esim_local_5_premium',
+      addonType: 'ESIM',
+      platform: 'ios',
+    },
+  };
+
+  test('returns 401 when no user is authenticated', async () => {
+    const app = buildUnauthedApp();
+
+    const res = await request(app)
+      .get(
+        '/billing/checkout-status?session_id=cs_test_esim_123'
+      );
+
+    expect(res.statusCode).toBe(401);
+
+    expect(res.body).toEqual({
+      error: 'Unauthorized',
+    });
+  });
+
+  test('returns 400 when session_id is missing', async () => {
+    const app = buildApp();
+
+    const res = await request(app)
+      .get('/billing/checkout-status');
+
+    expect(res.statusCode).toBe(400);
+
+    expect(res.body).toEqual({
+      error: 'session_id is required',
+    });
+  });
+
+  test('blocks a checkout session belonging to another user', async () => {
+    const app = buildApp();
+
+    stripeMock.checkout.sessions.retrieve
+      .mockResolvedValue({
+        ...paidEsimSession,
+        client_reference_id: '2',
+        metadata: {
+          ...paidEsimSession.metadata,
+          userId: '2',
+        },
+      });
+
+    const res = await request(app)
+      .get(
+        '/billing/checkout-status?session_id=cs_test_esim_123'
+      );
+
+    expect(res.statusCode).toBe(403);
+
+    expect(res.body).toEqual({
+      error:
+        'This checkout session does not belong to the authenticated user',
+    });
+  });
+
+  test('returns PENDING while the webhook has not created the purchase', async () => {
+    const app = buildApp();
+
+    stripeMock.checkout.sessions.retrieve
+      .mockResolvedValue(
+        paidEsimSession
+      );
+
+    prismaMock.mobileDataPackPurchase
+      .findFirst
+      .mockResolvedValue(null);
+
+    const res = await request(app)
+      .get(
+        '/billing/checkout-status?session_id=cs_test_esim_123'
+      );
+
+    expect(res.statusCode).toBe(200);
+
+    expect(
+      prismaMock.mobileDataPackPurchase
+        .findFirst
+    ).toHaveBeenCalledWith({
+      where: {
+        userId: 1,
+        billingTransactionId:
+          'pi_test_esim_123',
+      },
+      select: {
+        id: true,
+        addonKind: true,
+        totalDataMb: true,
+        remainingDataMb: true,
+        expiresAt: true,
+        esimProfileId: true,
+      },
+    });
+
+    expect(res.body).toEqual({
+      status: 'PENDING',
+      complete: false,
+      paid: true,
+      provisioned: false,
+      sessionId:
+        'cs_test_esim_123',
+      paymentStatus: 'paid',
+      sessionStatus: 'complete',
+      purchase: null,
+    });
+  });
+
+  test('returns COMPLETE after the webhook links the purchase and subscriber', async () => {
+    const app = buildApp();
+
+    const expiresAt =
+      new Date(
+        '2026-08-15T00:00:00.000Z'
+      );
+
+    stripeMock.checkout.sessions.retrieve
+      .mockResolvedValue(
+        paidEsimSession
+      );
+
+    prismaMock.mobileDataPackPurchase
+      .findFirst
+      .mockResolvedValue({
+        id: 22,
+        addonKind:
+          'chatforia_esim_local_5_premium',
+        totalDataMb: 8192,
+        remainingDataMb: 8192,
+        expiresAt,
+        esimProfileId:
+          'mock-telna-profile',
+      });
+
+    prismaMock.subscriber.findFirst
+      .mockResolvedValue({
+        id: 7,
+        status: 'ACTIVE',
+        providerProfileId:
+          'mock-telna-profile',
+        providerMeta: {
+          stripeSessionId:
+            'cs_test_esim_123',
+        },
+      });
+
+    const res = await request(app)
+      .get(
+        '/billing/checkout-status?session_id=cs_test_esim_123'
+      );
+
+    expect(res.statusCode).toBe(200);
+
+    expect(
+      prismaMock.subscriber.findFirst
+    ).toHaveBeenCalledWith({
+      where: {
+        userId: 1,
+        purchaseId: 22,
+      },
+      orderBy: [
+        {
+          activatedAt: 'desc',
+        },
+        {
+          createdAt: 'desc',
+        },
+      ],
+      select: {
+        id: true,
+        status: true,
+        providerProfileId: true,
+        providerMeta: true,
+      },
+    });
+
+    expect(res.body).toEqual({
+      status: 'COMPLETE',
+      complete: true,
+      paid: true,
+      provisioned: true,
+      sessionId:
+        'cs_test_esim_123',
+      paymentStatus: 'paid',
+      sessionStatus: 'complete',
+      purchase: {
+        id: 22,
+        addonKind:
+          'chatforia_esim_local_5_premium',
+        totalDataMb: 8192,
+        remainingDataMb: 8192,
+        expiresAt:
+          expiresAt.toISOString(),
       },
     });
   });

--- a/server/routes/billing.js
+++ b/server/routes/billing.js
@@ -329,6 +329,205 @@ router.get('/my-plan', async (req, res) => {
   }
 });
 
+router.get('/checkout-status', async (req, res) => {
+  try {
+    if (!req.user?.id) {
+      return res.status(401).json({
+        error: 'Unauthorized',
+      });
+    }
+
+    const userId = Number(req.user.id);
+
+    const sessionId = String(
+      req.query?.session_id || ''
+    ).trim();
+
+    if (!sessionId) {
+      return res.status(400).json({
+        error: 'session_id is required',
+      });
+    }
+
+    if (!sessionId.startsWith('cs_')) {
+      return res.status(400).json({
+        error: 'Invalid checkout session ID',
+      });
+    }
+
+    const session =
+      await stripe.checkout.sessions.retrieve(
+        sessionId
+      );
+
+    const sessionUserId =
+      Number(session.metadata?.userId) ||
+      Number(session.client_reference_id) ||
+      null;
+
+    if (
+      !sessionUserId ||
+      sessionUserId !== userId
+    ) {
+      return res.status(403).json({
+        error:
+          'This checkout session does not belong to the authenticated user',
+      });
+    }
+
+    const addonConfig = getAddonConfig(
+      session.metadata?.product
+    );
+
+    if (
+      session.mode !== 'payment' ||
+      addonConfig?.type !== 'ESIM'
+    ) {
+      return res.status(400).json({
+        error:
+          'This checkout session is not an eSIM purchase',
+      });
+    }
+
+    const paymentStatus = String(
+      session.payment_status || ''
+    )
+      .trim()
+      .toLowerCase();
+
+    const sessionStatus = String(
+      session.status || ''
+    )
+      .trim()
+      .toLowerCase();
+
+    const paid =
+      paymentStatus === 'paid';
+
+    const expired =
+      sessionStatus === 'expired';
+
+    const pendingResponse = {
+      status: expired ? 'EXPIRED' : 'PENDING',
+      complete: false,
+      paid,
+      provisioned: false,
+      sessionId: session.id,
+      paymentStatus: paymentStatus || null,
+      sessionStatus: sessionStatus || null,
+      purchase: null,
+    };
+
+    if (!paid) {
+      return res.json(pendingResponse);
+    }
+
+    const paymentIntentId =
+      typeof session.payment_intent === 'string'
+        ? session.payment_intent
+        : session.payment_intent?.id || null;
+
+    if (!paymentIntentId) {
+      return res.json(pendingResponse);
+    }
+
+    const purchase =
+      await prisma.mobileDataPackPurchase.findFirst({
+        where: {
+          userId,
+          billingTransactionId:
+            paymentIntentId,
+        },
+        select: {
+          id: true,
+          addonKind: true,
+          totalDataMb: true,
+          remainingDataMb: true,
+          expiresAt: true,
+          esimProfileId: true,
+        },
+      });
+
+    let subscriber = null;
+
+    if (purchase) {
+      subscriber =
+        await prisma.subscriber.findFirst({
+          where: {
+            userId,
+            purchaseId: purchase.id,
+          },
+          orderBy: [
+            {
+              activatedAt: 'desc',
+            },
+            {
+              createdAt: 'desc',
+            },
+          ],
+          select: {
+            id: true,
+            status: true,
+            providerProfileId: true,
+            providerMeta: true,
+          },
+        });
+    }
+
+    const webhookApplied = Boolean(
+      purchase?.esimProfileId &&
+      subscriber?.providerProfileId &&
+      subscriber?.providerMeta
+        ?.stripeSessionId === session.id
+    );
+
+    if (!webhookApplied) {
+      return res.json(pendingResponse);
+    }
+
+    return res.json({
+      status: 'COMPLETE',
+      complete: true,
+      paid: true,
+      provisioned: true,
+      sessionId: session.id,
+      paymentStatus,
+      sessionStatus,
+      purchase: {
+        id: purchase.id,
+        addonKind: purchase.addonKind,
+        totalDataMb:
+          purchase.totalDataMb,
+        remainingDataMb:
+          purchase.remainingDataMb,
+        expiresAt:
+          purchase.expiresAt,
+      },
+    });
+  } catch (err) {
+    if (err?.code === 'resource_missing') {
+      return res.status(404).json({
+        error:
+          'Checkout session not found',
+      });
+    }
+
+    console.error(
+      '[billing/checkout-status] error:',
+      {
+        message: err?.message,
+        type: err?.type,
+        code: err?.code,
+      }
+    );
+
+    return res.status(500).json({
+      error:
+        'Unable to check checkout status',
+    });
+  }
+});
+
 router.post('/checkout', async (req, res) => {
   try {
     if (!req.user?.id) {


### PR DESCRIPTION
## Summary

- adds authenticated `GET /billing/checkout-status`
- validates that the Stripe Checkout Session belongs to the authenticated user
- restricts the endpoint to eSIM payment sessions
- returns `PENDING` until the webhook creates and links the purchase
- returns `COMPLETE` only after the purchase and subscriber records are provisioned
- prevents the iOS app from confirming a purchase before webhook processing finishes

## Tests

- `node --check routes/billing.js`
- `npm test -- --runInBand --coverage=false __tests__/billing.test.js __tests__/billing-webhook.test.js`
- 2 suites passed
- 31 tests passed
- `git diff --check`