### PR TITLE
Add Apple StoreKit entitlement sync

### DIFF
--- a/server/__tests__/appleEntitlementService.test.js
+++ b/server/__tests__/appleEntitlementService.test.js
@@ -1,0 +1,276 @@
+/**
+ * @jest-environment node
+ */
+import { jest } from '@jest/globals';
+
+process.env.APPLE_BUNDLE_ID = 'com.chatforia.Chatforia';
+
+process.env.APPLE_IAP_ENV = 'sandbox';
+
+let assertProviderAvailableMock;
+let recomputeEntitlementMock;
+let verifyAndApplyAppleSubscription;
+
+await jest.unstable_mockModule('../utils/prismaClient.js', () => ({
+  __esModule: true,
+  default: {},
+}));
+
+await jest.unstable_mockModule('../services/appEntitlementService.js', () => {
+  assertProviderAvailableMock = jest.fn();
+
+  recomputeEntitlementMock = jest.fn();
+
+  return {
+    __esModule: true,
+
+    assertAppSubscriptionProviderAvailable: assertProviderAvailableMock,
+
+    recomputeUserAppEntitlement: recomputeEntitlementMock,
+  };
+});
+
+({ verifyAndApplyAppleSubscription } = await import(
+  '../services/appleEntitlementService.js'
+));
+
+const NOW = new Date('2026-07-16T23:00:00.000Z');
+
+function makeTransaction(overrides = {}) {
+  return {
+    bundleId: 'com.chatforia.Chatforia',
+
+    environment: 'Sandbox',
+
+    transactionId: '2000001234567890',
+
+    originalTransactionId: '2000001234567000',
+
+    productId: 'plus.monthly',
+
+    purchaseDate: NOW.getTime() - 60_000,
+
+    expiresDate: NOW.getTime() + 86_400_000,
+
+    appAccountToken: null,
+
+    revocationDate: null,
+
+    ...overrides,
+  };
+}
+
+function makeDb(existing = null) {
+  const db = {
+    appSubscription: {
+      findUnique: jest.fn().mockResolvedValue(existing),
+
+      upsert: jest.fn().mockResolvedValue({
+        id: 'apple-subscription-1',
+      }),
+    },
+  };
+
+  db.$transaction = jest.fn(async (callback) => callback(db));
+
+  return db;
+}
+
+function makeActiveUser() {
+  return {
+    id: 1,
+    plan: 'PLUS',
+    subscriptionStatus: 'ACTIVE',
+    subscriptionEndsAt: new Date(NOW.getTime() + 86_400_000),
+    billingProvider: 'APPLE',
+    billingSubscriptionId: '2000001234567000',
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+
+  assertProviderAvailableMock.mockResolvedValue(null);
+
+  recomputeEntitlementMock.mockResolvedValue({
+    user: makeActiveUser(),
+    selectedEntitlement: {
+      provider: 'APPLE',
+      plan: 'PLUS',
+    },
+  });
+});
+
+test('creates an active Apple Plus entitlement', async () => {
+  const db = makeDb();
+  const transaction = makeTransaction();
+
+  const result = await verifyAndApplyAppleSubscription({
+    userId: 1,
+    signedTransactionInfo: 'signed-apple-jws',
+    db,
+    now: NOW,
+
+    verifyTransaction: jest.fn().mockResolvedValue(transaction),
+  });
+
+  expect(assertProviderAvailableMock).toHaveBeenCalledWith(1, 'APPLE', {
+    db,
+    now: NOW,
+  });
+
+  expect(db.appSubscription.upsert).toHaveBeenCalledWith(
+    expect.objectContaining({
+      where: {
+        provider_providerSubscriptionKey: {
+          provider: 'APPLE',
+          providerSubscriptionKey: '2000001234567000',
+        },
+      },
+
+      create: expect.objectContaining({
+        userId: 1,
+        provider: 'APPLE',
+        productId: 'plus.monthly',
+        plan: 'PLUS',
+        status: 'ACTIVE',
+        grantsAccess: true,
+        autoRenewEnabled: null,
+        basePlanId: 'monthly',
+      }),
+    })
+  );
+
+  expect(result).toMatchObject({
+    grantsAccess: true,
+    status: 'ACTIVE',
+    alreadyLinked: false,
+
+    user: {
+      plan: 'PLUS',
+      subscriptionStatus: 'ACTIVE',
+      billingProvider: 'APPLE',
+    },
+  });
+});
+
+test('updates an Apple subscription already linked to the same user', async () => {
+  const db = makeDb({
+    id: 'apple-subscription-1',
+    userId: 1,
+    customerReference: null,
+  });
+
+  const result = await verifyAndApplyAppleSubscription({
+    userId: 1,
+    signedTransactionInfo: 'signed-apple-jws',
+    db,
+    now: NOW,
+
+    verifyTransaction: jest.fn().mockResolvedValue(makeTransaction()),
+  });
+
+  expect(result.alreadyLinked).toBe(true);
+
+  expect(db.appSubscription.upsert).toHaveBeenCalledTimes(1);
+});
+
+test('rejects a subscription linked to another Chatforia user', async () => {
+  const db = makeDb({
+    id: 'apple-subscription-1',
+    userId: 2,
+    customerReference: null,
+  });
+
+  await expect(
+    verifyAndApplyAppleSubscription({
+      userId: 1,
+      signedTransactionInfo: 'signed-apple-jws',
+      db,
+      now: NOW,
+
+      verifyTransaction: jest.fn().mockResolvedValue(makeTransaction()),
+    })
+  ).rejects.toMatchObject({
+    code: 'APPLE_SUBSCRIPTION_ALREADY_LINKED',
+    statusCode: 409,
+  });
+
+  expect(assertProviderAvailableMock).not.toHaveBeenCalled();
+
+  expect(db.appSubscription.upsert).not.toHaveBeenCalled();
+});
+
+test('stores an expired Apple subscription without granting access', async () => {
+  const db = makeDb();
+
+  recomputeEntitlementMock.mockResolvedValue({
+    user: {
+      id: 1,
+      plan: 'FREE',
+      subscriptionStatus: 'INACTIVE',
+      subscriptionEndsAt: null,
+      billingProvider: null,
+      billingSubscriptionId: null,
+    },
+
+    selectedEntitlement: null,
+  });
+
+  const result = await verifyAndApplyAppleSubscription({
+    userId: 1,
+    signedTransactionInfo: 'signed-apple-jws',
+    db,
+    now: NOW,
+
+    verifyTransaction: jest.fn().mockResolvedValue(
+      makeTransaction({
+        expiresDate: NOW.getTime() - 1,
+      })
+    ),
+  });
+
+  expect(db.appSubscription.upsert).toHaveBeenCalledWith(
+    expect.objectContaining({
+      create: expect.objectContaining({
+        status: 'EXPIRED',
+        grantsAccess: false,
+        autoRenewEnabled: null,
+      }),
+    })
+  );
+
+  expect(result).toMatchObject({
+    grantsAccess: false,
+    status: 'EXPIRED',
+    user: {
+      plan: 'FREE',
+    },
+  });
+});
+
+test('rejects an Apple transaction for another bundle', async () => {
+  const db = makeDb();
+
+  await expect(
+    verifyAndApplyAppleSubscription({
+      userId: 1,
+      signedTransactionInfo: 'signed-apple-jws',
+      db,
+      now: NOW,
+
+      verifyTransaction: jest.fn().mockResolvedValue(
+        makeTransaction({
+          bundleId: 'com.example.other-app',
+        })
+      ),
+    })
+  ).rejects.toMatchObject({
+    code: 'APPLE_BUNDLE_ID_MISMATCH',
+    statusCode: 400,
+  });
+
+  expect(db.appSubscription.findUnique).not.toHaveBeenCalled();
+
+  expect(db.appSubscription.upsert).not.toHaveBeenCalled();
+});

--- a/server/__tests__/billing-ios-sync.test.js
+++ b/server/__tests__/billing-ios-sync.test.js
@@ -1,0 +1,242 @@
+/**
+ * @jest-environment node
+ */
+import { jest } from '@jest/globals';
+import express from 'express';
+import request from 'supertest';
+
+process.env.NODE_ENV = 'test';
+process.env.STRIPE_SECRET_KEY = 'sk_test_apple_sync';
+
+let billingRouter;
+let verifyAppleSubscriptionMock;
+
+await jest.unstable_mockModule('../utils/prismaClient.js', () => {
+  const prismaMock = {
+    user: {
+      findUnique: jest.fn(),
+      update: jest.fn(),
+    },
+
+    appSubscription: {
+      findFirst: jest.fn(),
+      updateMany: jest.fn(),
+    },
+
+    mobileDataPackPurchase: {
+      findFirst: jest.fn(),
+    },
+
+    subscriber: {
+      findFirst: jest.fn(),
+    },
+
+    $transaction: jest.fn(async (callback) => callback(prismaMock)),
+  };
+
+  return {
+    __esModule: true,
+    default: prismaMock,
+  };
+});
+
+await jest.unstable_mockModule('../services/appEntitlementService.js', () => ({
+  __esModule: true,
+
+  assertAppSubscriptionProviderAvailable: jest.fn(),
+
+  recomputeUserAppEntitlement: jest.fn(),
+}));
+
+await jest.unstable_mockModule(
+  '../services/googlePlayEntitlementService.js',
+  () => ({
+    __esModule: true,
+
+    verifyAndApplyGooglePlaySubscription: jest.fn(),
+  })
+);
+
+await jest.unstable_mockModule('../services/appleEntitlementService.js', () => {
+  verifyAppleSubscriptionMock = jest.fn();
+
+  return {
+    __esModule: true,
+
+    verifyAndApplyAppleSubscription: verifyAppleSubscriptionMock,
+  };
+});
+
+await jest.unstable_mockModule('stripe', () => {
+  const stripeMock = {
+    customers: {
+      create: jest.fn(),
+    },
+
+    subscriptions: {
+      retrieve: jest.fn(),
+      cancel: jest.fn(),
+    },
+
+    checkout: {
+      sessions: {
+        create: jest.fn(),
+        retrieve: jest.fn(),
+      },
+    },
+
+    billingPortal: {
+      sessions: {
+        create: jest.fn(),
+      },
+    },
+  };
+
+  return {
+    __esModule: true,
+    default: jest.fn(() => stripeMock),
+  };
+});
+
+({ default: billingRouter } = await import('../routes/billing.js'));
+
+function buildApp({ authenticated = true } = {}) {
+  const app = express();
+
+  app.use(express.json());
+
+  app.use('/billing', (req, _res, next) => {
+    req.user = authenticated
+      ? {
+          id: 1,
+          email: 'apple-user@test.com',
+        }
+      : null;
+
+    next();
+  });
+
+  app.use('/billing', billingRouter);
+
+  return app;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  verifyAppleSubscriptionMock.mockReset();
+});
+
+test('POST /billing/ios-sync requires authentication', async () => {
+  const app = buildApp({
+    authenticated: false,
+  });
+
+  const response = await request(app).post('/billing/ios-sync').send({
+    signedTransactionInfo: 'signed-jws',
+  });
+
+  expect(response.statusCode).toBe(401);
+
+  expect(response.body).toEqual({
+    ok: false,
+    error: 'Unauthorized',
+    code: 'UNAUTHORIZED',
+  });
+
+  expect(verifyAppleSubscriptionMock).not.toHaveBeenCalled();
+});
+
+test('POST /billing/ios-sync requires a signed transaction', async () => {
+  const app = buildApp();
+
+  const response = await request(app).post('/billing/ios-sync').send({});
+
+  expect(response.statusCode).toBe(400);
+
+  expect(response.body).toEqual({
+    ok: false,
+    error: 'A signed Apple transaction is required.',
+    code: 'APPLE_TRANSACTION_REQUIRED',
+  });
+
+  expect(verifyAppleSubscriptionMock).not.toHaveBeenCalled();
+});
+
+test('POST /billing/ios-sync returns the synchronized Apple entitlement', async () => {
+  const app = buildApp();
+
+  const expiresAt = new Date('2026-07-17T23:00:00.000Z');
+
+  verifyAppleSubscriptionMock.mockResolvedValue({
+    user: {
+      id: 1,
+      plan: 'PLUS',
+      subscriptionStatus: 'ACTIVE',
+      subscriptionEndsAt: expiresAt,
+      billingProvider: 'APPLE',
+      billingSubscriptionId: '2000001234567000',
+    },
+
+    transaction: {
+      productId: 'plus.monthly',
+    },
+
+    grantsAccess: true,
+    alreadyLinked: false,
+  });
+
+  const response = await request(app).post('/billing/ios-sync').send({
+    signedTransactionInfo: 'signed-jws',
+    source: 'ios_storekit2',
+  });
+
+  expect(response.statusCode).toBe(200);
+
+  expect(verifyAppleSubscriptionMock).toHaveBeenCalledWith({
+    userId: 1,
+    signedTransactionInfo: 'signed-jws',
+  });
+
+  expect(response.body).toEqual({
+    ok: true,
+    provider: 'APPLE',
+    plan: 'PLUS',
+    status: 'ACTIVE',
+    expiresAt: expiresAt.toISOString(),
+    productId: 'plus.monthly',
+    grantsAccess: true,
+    alreadyLinked: false,
+  });
+});
+
+test('POST /billing/ios-sync preserves service errors', async () => {
+  const app = buildApp();
+
+  const error = new Error(
+    'This Apple subscription is already linked to another Chatforia account.'
+  );
+
+  error.statusCode = 409;
+  error.code = 'APPLE_SUBSCRIPTION_ALREADY_LINKED';
+
+  verifyAppleSubscriptionMock.mockRejectedValue(error);
+
+  const consoleError = jest
+    .spyOn(console, 'error')
+    .mockImplementation(() => {});
+
+  const response = await request(app).post('/billing/ios-sync').send({
+    signedTransactionInfo: 'signed-jws',
+  });
+
+  consoleError.mockRestore();
+
+  expect(response.statusCode).toBe(409);
+
+  expect(response.body).toEqual({
+    ok: false,
+    error:
+      'This Apple subscription is already linked to another Chatforia account.',
+    code: 'APPLE_SUBSCRIPTION_ALREADY_LINKED',
+  });
+});

--- a/server/config/appleIapConfig.js
+++ b/server/config/appleIapConfig.js
@@ -1,23 +1,29 @@
 const appleIapConfig = {
-  bundleId: process.env.APPLE_BUNDLE_ID || 'com.chatforia.app',
+  bundleId: process.env.APPLE_BUNDLE_ID || 'com.chatforia.Chatforia',
   environment: (process.env.APPLE_IAP_ENV || 'sandbox').toLowerCase(), // sandbox | production
 
   products: {
     // Subscriptions
     plus_monthly: {
-      productId: 'com.chatforia.plus.monthly',
+      productId: 'plus.monthly',
+      aliases: ['com.chatforia.plus.monthly'],
       kind: 'subscription',
       plan: 'PLUS',
+      billingPeriod: 'monthly',
     },
     premium_monthly: {
-      productId: 'com.chatforia.premium.monthly',
+      productId: 'premium.monthly',
+      aliases: ['com.chatforia.premium.monthly'],
       kind: 'subscription',
       plan: 'PREMIUM',
+      billingPeriod: 'monthly',
     },
     premium_annual: {
-      productId: 'com.chatforia.premium.annual',
+      productId: 'premium.annual',
+      aliases: ['com.chatforia.premium.annual'],
       kind: 'subscription',
       plan: 'PREMIUM',
+      billingPeriod: 'annual',
     },
 
     // Add-ons / data packs
@@ -96,10 +102,18 @@ const appleIapConfig = {
   },
 };
 
-const productsById = Object.values(appleIapConfig.products).reduce((acc, product) => {
-  acc[product.productId] = product;
-  return acc;
-}, {});
+const productsById = Object.values(appleIapConfig.products).reduce(
+  (acc, product) => {
+    const productIds = [product.productId, ...(product.aliases || [])];
+
+    for (const productId of productIds) {
+      acc[productId] = product;
+    }
+
+    return acc;
+  },
+  {}
+);
 
 export function getAppleProduct(productId) {
   return productsById[String(productId || '').trim()] || null;

--- a/server/routes/billing.js
+++ b/server/routes/billing.js
@@ -7,6 +7,7 @@ import {
   assertAppSubscriptionProviderAvailable,
   recomputeUserAppEntitlement,
 } from '../services/appEntitlementService.js';
+import { verifyAndApplyAppleSubscription } from '../services/appleEntitlementService.js';
 
 const router = express.Router();
 
@@ -1088,6 +1089,78 @@ router.post('/cancel-now', async (req, res) => {
     return res.status(500).json({
       error: 'Failed to cancel subscription',
       code: 'SUBSCRIPTION_CANCEL_FAILED',
+    });
+  }
+});
+
+router.post('/ios-sync', async (req, res) => {
+  if (!req.user?.id) {
+    return res.status(401).json({
+      ok: false,
+      error: 'Unauthorized',
+      code: 'UNAUTHORIZED',
+    });
+  }
+
+  const signedTransactionInfo =
+    typeof req.body?.signedTransactionInfo === 'string'
+      ? req.body.signedTransactionInfo.trim()
+      : '';
+
+  if (!signedTransactionInfo) {
+    return res.status(400).json({
+      ok: false,
+      error: 'A signed Apple transaction is required.',
+      code: 'APPLE_TRANSACTION_REQUIRED',
+    });
+  }
+
+  try {
+    const result =
+      await verifyAndApplyAppleSubscription({
+        userId: req.user.id,
+        signedTransactionInfo,
+      });
+
+    return res.json({
+      ok: true,
+      provider: 'APPLE',
+      plan: result.user.plan,
+      status:
+        result.user.subscriptionStatus,
+      expiresAt:
+        result.user.subscriptionEndsAt
+          ?.toISOString?.() ?? null,
+      productId:
+        result.transaction.productId,
+      grantsAccess:
+        result.grantsAccess,
+      alreadyLinked:
+        result.alreadyLinked,
+    });
+  } catch (err) {
+    const statusCode =
+      Number.isInteger(err?.statusCode)
+        ? err.statusCode
+        : 500;
+
+    console.error(
+      '[billing/ios-sync] error:',
+      {
+        message: err?.message ?? null,
+        code: err?.code ?? null,
+        userId: req.user?.id ?? null,
+      }
+    );
+
+    return res.status(statusCode).json({
+      ok: false,
+      error:
+        err?.message ||
+        'Apple subscription verification failed.',
+      code:
+        err?.code ||
+        'APPLE_SUBSCRIPTION_VERIFICATION_FAILED',
     });
   }
 });

--- a/server/services/appleEntitlementService.js
+++ b/server/services/appleEntitlementService.js
@@ -1,0 +1,286 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  Environment,
+  SignedDataVerifier,
+} from '@apple/app-store-server-library';
+
+import prisma from '../utils/prismaClient.js';
+import appleIapConfig, { getAppleProduct } from '../config/appleIapConfig.js';
+
+import {
+  assertAppSubscriptionProviderAvailable,
+  recomputeUserAppEntitlement,
+} from './appEntitlementService.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+let appleVerifier = null;
+
+function makeError(message, code, statusCode = 400) {
+  const error = new Error(message);
+  error.code = code;
+  error.statusCode = statusCode;
+  return error;
+}
+
+function normalizeUserId(userId) {
+  const value = Number(userId);
+
+  if (!Number.isInteger(value) || value <= 0) {
+    throw makeError('A valid user ID is required.', 'INVALID_USER_ID');
+  }
+
+  return value;
+}
+
+function safeDateFromMs(value) {
+  if (value == null) {
+    return null;
+  }
+
+  const date = new Date(Number(value));
+
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function expectedAppleEnvironment() {
+  return appleIapConfig.environment === 'production' ? 'Production' : 'Sandbox';
+}
+
+function getAppleVerifier() {
+  if (appleVerifier) {
+    return appleVerifier;
+  }
+
+  const appleRootCAs = [
+    fs.readFileSync(path.join(__dirname, '../certs/AppleRootCA.cer')),
+    fs.readFileSync(path.join(__dirname, '../certs/AppleRootCA-G3.cer')),
+  ];
+
+  const environment =
+    appleIapConfig.environment === 'production'
+      ? Environment.PRODUCTION
+      : Environment.SANDBOX;
+
+  appleVerifier = new SignedDataVerifier(
+    appleRootCAs,
+    true,
+    environment,
+    appleIapConfig.bundleId,
+    process.env.APPLE_APP_ID ? Number(process.env.APPLE_APP_ID) : undefined
+  );
+
+  return appleVerifier;
+}
+
+export async function verifyAppleTransaction(signedTransactionInfo) {
+  try {
+    return await getAppleVerifier().verifyAndDecodeTransaction(
+      signedTransactionInfo
+    );
+  } catch {
+    throw makeError(
+      'Apple could not verify this transaction.',
+      'APPLE_TRANSACTION_VERIFICATION_FAILED'
+    );
+  }
+}
+
+export async function verifyAndApplyAppleSubscription({
+  userId,
+  signedTransactionInfo,
+  db = prisma,
+  now = new Date(),
+  verifyTransaction = verifyAppleTransaction,
+}) {
+  const normalizedUserId = normalizeUserId(userId);
+
+  const signedValue =
+    typeof signedTransactionInfo === 'string'
+      ? signedTransactionInfo.trim()
+      : '';
+
+  if (!signedValue) {
+    throw makeError(
+      'A signed Apple transaction is required.',
+      'APPLE_TRANSACTION_REQUIRED'
+    );
+  }
+
+  const transaction = await verifyTransaction(signedValue);
+
+  if (transaction.bundleId !== appleIapConfig.bundleId) {
+    throw makeError(
+      'The Apple transaction bundle ID is invalid.',
+      'APPLE_BUNDLE_ID_MISMATCH'
+    );
+  }
+
+  const expectedEnvironment = expectedAppleEnvironment();
+
+  if (
+    transaction.environment &&
+    transaction.environment !== expectedEnvironment
+  ) {
+    throw makeError(
+      'The Apple transaction environment is invalid.',
+      'APPLE_ENVIRONMENT_MISMATCH'
+    );
+  }
+
+  const appleProduct = getAppleProduct(transaction.productId);
+
+  if (!appleProduct || appleProduct.kind !== 'subscription') {
+    throw makeError(
+      'This Apple product is not a supported Chatforia subscription.',
+      'APPLE_PRODUCT_NOT_SUPPORTED'
+    );
+  }
+
+  const providerSubscriptionKey = String(
+    transaction.originalTransactionId || transaction.transactionId || ''
+  ).trim();
+
+  if (!providerSubscriptionKey) {
+    throw makeError(
+      'The Apple transaction has no subscription identifier.',
+      'APPLE_SUBSCRIPTION_ID_MISSING'
+    );
+  }
+
+  const existing = await db.appSubscription.findUnique({
+    where: {
+      provider_providerSubscriptionKey: {
+        provider: 'APPLE',
+        providerSubscriptionKey,
+      },
+    },
+    select: {
+      id: true,
+      userId: true,
+      customerReference: true,
+    },
+  });
+
+  if (existing && existing.userId !== normalizedUserId) {
+    throw makeError(
+      'This Apple subscription is already linked to another Chatforia account.',
+      'APPLE_SUBSCRIPTION_ALREADY_LINKED',
+      409
+    );
+  }
+
+  await assertAppSubscriptionProviderAvailable(normalizedUserId, 'APPLE', {
+    db,
+    now,
+  });
+
+  const startsAt = safeDateFromMs(transaction.purchaseDate);
+
+  const endsAt = safeDateFromMs(transaction.expiresDate);
+
+  const revokedAt = safeDateFromMs(transaction.revocationDate);
+
+  const grantsAccess =
+    !revokedAt && (!endsAt || endsAt.getTime() > now.getTime());
+
+  const status = revokedAt ? 'REVOKED' : grantsAccess ? 'ACTIVE' : 'EXPIRED';
+
+  const appAccountToken = transaction.appAccountToken
+    ? String(transaction.appAccountToken)
+    : existing?.customerReference || null;
+
+  const result = await db.$transaction(async (tx) => {
+    const subscription = await tx.appSubscription.upsert({
+      where: {
+        provider_providerSubscriptionKey: {
+          provider: 'APPLE',
+          providerSubscriptionKey,
+        },
+      },
+
+      create: {
+        userId: normalizedUserId,
+        provider: 'APPLE',
+        providerSubscriptionKey,
+        customerReference: appAccountToken,
+        productId: transaction.productId,
+        basePlanId: appleProduct.billingPeriod || null,
+        plan: appleProduct.plan,
+        status,
+        grantsAccess,
+        autoRenewEnabled: null,
+        startsAt,
+        endsAt,
+        lastVerifiedAt: now,
+
+        rawResponse: {
+          source: 'ios_storekit2',
+          environment: transaction.environment || expectedEnvironment,
+          bundleId: transaction.bundleId,
+          transactionId: transaction.transactionId
+            ? String(transaction.transactionId)
+            : null,
+          originalTransactionId: providerSubscriptionKey,
+          productId: transaction.productId,
+          appAccountToken,
+          purchaseDate: transaction.purchaseDate ?? null,
+          expiresDate: transaction.expiresDate ?? null,
+          revocationDate: transaction.revocationDate ?? null,
+        },
+      },
+
+      update: {
+        userId: normalizedUserId,
+        customerReference: appAccountToken,
+        productId: transaction.productId,
+        basePlanId: appleProduct.billingPeriod || null,
+        plan: appleProduct.plan,
+        status,
+        grantsAccess,
+        autoRenewEnabled: null,
+        startsAt,
+        endsAt,
+        lastVerifiedAt: now,
+
+        rawResponse: {
+          source: 'ios_storekit2',
+          environment: transaction.environment || expectedEnvironment,
+          bundleId: transaction.bundleId,
+          transactionId: transaction.transactionId
+            ? String(transaction.transactionId)
+            : null,
+          originalTransactionId: providerSubscriptionKey,
+          productId: transaction.productId,
+          appAccountToken,
+          purchaseDate: transaction.purchaseDate ?? null,
+          expiresDate: transaction.expiresDate ?? null,
+          revocationDate: transaction.revocationDate ?? null,
+        },
+      },
+    });
+
+    const entitlement = await recomputeUserAppEntitlement(normalizedUserId, {
+      db: tx,
+      now,
+    });
+
+    return {
+      subscription,
+      entitlement,
+    };
+  });
+
+  return {
+    transaction,
+    subscription: result.subscription,
+    user: result.entitlement.user,
+    grantsAccess,
+    status,
+    alreadyLinked: Boolean(existing),
+  };
+}


### PR DESCRIPTION
## Summary

- adds authenticated `POST /billing/ios-sync`
- verifies StoreKit signed transaction data on the backend
- supports current Apple product IDs and fully qualified aliases
- creates or updates Apple `AppSubscription` records
- prevents the same Apple subscription from being linked to another Chatforia user
- recomputes the user’s effective Chatforia entitlement
- adds service and route tests

## Validation

- 34 relevant tests passed
- Prettier checks passed for the changed Apple files
- JavaScript syntax checks passed
- `git diff --check` passed

## Notes

- production is currently configured with `APPLE_IAP_ENV=sandbox` for StoreKit Sandbox testing
- ESLint could not start because the repository is missing `eslint-plugin-jsx-a11y`
- the full server suite has 13 unrelated pre-existing failing suites