### PR TITLE
Fix Stripe subscription period extraction

### DIFF
--- a/server/__tests__/billing-webhook.test.js
+++ b/server/__tests__/billing-webhook.test.js
@@ -48,29 +48,28 @@ function makeActiveStripeSubscription({
 } = {}) {
   const now = Date.now();
 
+  const currentPeriodStart =
+    unixSeconds(
+      new Date(now - 60_000)
+    );
+
+  const currentPeriodEnd =
+    unixSeconds(
+      new Date(
+        now +
+          30 *
+            24 *
+            60 *
+            60 *
+            1000
+      )
+    );
+
   return {
     object: 'subscription',
     id,
     customer,
     status: 'active',
-
-    current_period_start:
-      unixSeconds(
-        new Date(now - 60_000)
-      ),
-
-    current_period_end:
-      unixSeconds(
-        new Date(
-          now +
-            30 *
-              24 *
-              60 *
-              60 *
-              1000
-        )
-      ),
-
     cancel_at_period_end: false,
 
     metadata: {
@@ -81,6 +80,12 @@ function makeActiveStripeSubscription({
       data: [
         {
           object: 'subscription_item',
+
+          current_period_start:
+            currentPeriodStart,
+
+          current_period_end:
+            currentPeriodEnd,
 
           price: {
             id: priceId,
@@ -93,22 +98,34 @@ function makeActiveStripeSubscription({
   };
 }
 
+
 function makeCanceledStripeSubscription({
   id = 'sub_live_abc',
   userId = TEST_USER_ID,
   customer = 'cus_live_999',
 } = {}) {
+  const currentPeriodEnd =
+    unixSeconds();
+
   return {
     object: 'subscription',
     id,
     customer,
     status: 'canceled',
-    current_period_end:
-      unixSeconds(),
     cancel_at_period_end: false,
 
     metadata: {
       userId: String(userId),
+    },
+
+    items: {
+      data: [
+        {
+          object: 'subscription_item',
+          current_period_end:
+            currentPeriodEnd,
+        },
+      ],
     },
 
     livemode: false,
@@ -616,6 +633,28 @@ describe(
               },
             });
 
+
+        const subscriptionItem =
+          subscription.items.data[0];
+
+        expect(
+          appSubscription.startsAt
+        ).toEqual(
+          new Date(
+            subscriptionItem.current_period_start *
+              1000
+          )
+        );
+
+        expect(
+          appSubscription.endsAt
+        ).toEqual(
+          new Date(
+            subscriptionItem.current_period_end *
+              1000
+          )
+        );
+
         expect(
           appSubscription
         ).toEqual(
@@ -689,7 +728,10 @@ describe(
               'ACTIVE',
 
             subscriptionEndsAt:
-              expect.any(Date),
+              new Date(
+                subscription.items.data[0]
+                  .current_period_end * 1000
+              ),
           })
         );
       }

--- a/server/routes/billingWebhook.js
+++ b/server/routes/billingWebhook.js
@@ -36,6 +36,21 @@ function dateFromUnix(seconds) {
   return Number.isNaN(date.getTime()) ? null : date;
 }
 
+function getSubscriptionPeriod(subscription) {
+  const item = subscription.items?.data?.[0];
+
+  return {
+    startsAt: dateFromUnix(
+      item?.current_period_start ??
+        subscription.current_period_start
+    ),
+    endsAt: dateFromUnix(
+      item?.current_period_end ??
+        subscription.current_period_end
+    ),
+  };
+}
+
 async function hasProcessedStripeEvent(eventId) {
   const existing = await prisma.stripeWebhookEvent.findUnique({
     where: { id: String(eventId) },
@@ -123,6 +138,11 @@ async function applyActiveSubscription(
 
   const item =
     subscription.items?.data?.[0];
+
+  const {
+    startsAt: subscriptionStartsAt,
+    endsAt: subscriptionEndsAt,
+  } = getSubscriptionPeriod(subscription);
 
   const priceId =
     item?.price?.id || null;
@@ -284,15 +304,8 @@ async function applyActiveSubscription(
               !subscription
                 .cancel_at_period_end,
 
-            startsAt:
-              dateFromUnix(
-                subscription.current_period_start
-              ),
-
-            endsAt:
-              dateFromUnix(
-                subscription.current_period_end
-              ),
+            startsAt: subscriptionStartsAt,
+            endsAt: subscriptionEndsAt,
 
             lastVerifiedAt:
               now,
@@ -325,15 +338,8 @@ async function applyActiveSubscription(
               !subscription
                 .cancel_at_period_end,
 
-            startsAt:
-              dateFromUnix(
-                subscription.current_period_start
-              ),
-
-            endsAt:
-              dateFromUnix(
-                subscription.current_period_end
-              ),
+            startsAt: subscriptionStartsAt,
+            endsAt: subscriptionEndsAt,
 
             lastVerifiedAt:
               now,
@@ -450,6 +456,10 @@ async function markSubscriptionCanceledOrPastDue(
 
   const now = new Date();
 
+  const {
+    endsAt: subscriptionEndsAt,
+  } = getSubscriptionPeriod(subscription);
+
   const keepsAccess =
     normalizedStatus === 'PAST_DUE';
 
@@ -477,10 +487,7 @@ async function markSubscriptionCanceledOrPastDue(
                 ? !subscription.cancel_at_period_end
                 : false,
 
-            endsAt:
-              dateFromUnix(
-                subscription.current_period_end
-              ) || now,
+            endsAt: subscriptionEndsAt || now,
 
             lastVerifiedAt:
               now,


### PR DESCRIPTION
## Summary
- Reads Stripe subscription period dates from the subscription item
- Keeps top-level fields as compatibility fallbacks
- Applies the dates to new and existing Stripe entitlement rows
- Uses the item-level period end for canceled and past-due subscriptions
- Updates webhook tests to match Stripe’s current response shape

## Testing
- billing-webhook.test.js
- 6 tests passed