### PR TITLE
Show active-through date for canceled subscriptions

### DIFF
--- a/client/src/components/UserProfile.jsx
+++ b/client/src/components/UserProfile.jsx
@@ -918,7 +918,9 @@ export default function UserProfile({ onLanguageChange, openSection }) {
 
                       {planInfo.renewsAt && (
                         <Text size="xs" c="dimmed" mt="xs">
-                          {t('profile.planRenewsOn', 'Renews on')}{' '}
+                          {planInfo.autoRenewEnabled === false
+                            ? t('billing.activeThrough', 'Active through')
+                            : t('profile.planRenewsOn', 'Renews on')}{' '}
                           {new Date(planInfo.renewsAt).toLocaleDateString()}
                         </Text>
                       )}

--- a/client/src/pages/MyPlan.jsx
+++ b/client/src/pages/MyPlan.jsx
@@ -168,7 +168,14 @@ export default function MyPlan() {
                   {!plan.isFree && (
                     <Text mt={6} size="sm" c="dimmed">
                       {plan.renewsAt
-                        ? `${t('billing.renewsAt', 'Renews on')} ${new Date(plan.renewsAt).toLocaleDateString()}`
+                        ? `${t(
+                            plan.autoRenewEnabled === false
+                              ? 'billing.activeThrough'
+                              : 'billing.renewsAt',
+                            plan.autoRenewEnabled === false
+                              ? 'Active through'
+                              : 'Renews on'
+                          )} ${new Date(plan.renewsAt).toLocaleDateString()}`
                         : t('billing.activeSubscription', 'Your subscription is active.')}
                     </Text>
                   )}

--- a/client/src/pages/__tests__/MyPlan.test.js
+++ b/client/src/pages/__tests__/MyPlan.test.js
@@ -128,6 +128,7 @@ describe('MyPlan page', () => {
           currency: 'usd',
           interval: 'month',
           renewsAt: '2030-01-01T00:00:00.000Z',
+          autoRenewEnabled: true,
         },
       },
     });
@@ -163,6 +164,34 @@ describe('MyPlan page', () => {
     ).toBeInTheDocument();
 
     expect(mockGet).toHaveBeenCalledWith('/billing/my-plan');
+  });
+
+  test('shows active-through text for a scheduled cancellation', async () => {
+    mockGet.mockResolvedValueOnce({
+      data: {
+        plan: {
+          label: 'Chatforia Premium',
+          isFree: false,
+          status: 'ACTIVE',
+          renewsAt: '2030-01-01T00:00:00.000Z',
+          autoRenewEnabled: false,
+        },
+      },
+    });
+
+    renderWithRouter();
+
+    expect(
+      await screen.findByText('Chatforia Premium')
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByText(/active through/i)
+    ).toBeInTheDocument();
+
+    expect(
+      screen.queryByText(/renews on/i)
+    ).not.toBeInTheDocument();
   });
 
   test('shows error message when request fails', async () => {

--- a/server/__tests__/billing.test.js
+++ b/server/__tests__/billing.test.js
@@ -9,6 +9,7 @@ let prismaMock;
 let stripeMock;
 let billingRouter;
 let recomputeUserAppEntitlementMock;
+let getEffectiveAppEntitlementMock;
 let assertAppSubscriptionProviderAvailableMock;
 let verifyAndApplyGooglePlaySubscriptionMock;
 
@@ -76,6 +77,9 @@ beforeAll(async () => {
       recomputeUserAppEntitlementMock =
         jest.fn();
 
+      getEffectiveAppEntitlementMock =
+        jest.fn();
+
       assertAppSubscriptionProviderAvailableMock =
         jest.fn();
 
@@ -84,6 +88,9 @@ beforeAll(async () => {
 
         recomputeUserAppEntitlement:
           recomputeUserAppEntitlementMock,
+
+        getEffectiveAppEntitlement:
+          getEffectiveAppEntitlementMock,
 
         assertAppSubscriptionProviderAvailable:
           assertAppSubscriptionProviderAvailableMock,
@@ -156,6 +163,10 @@ beforeEach(() => {
   recomputeUserAppEntitlementMock
     .mockReset();
 
+  getEffectiveAppEntitlementMock
+    .mockReset()
+    .mockResolvedValue(null);
+
   verifyAndApplyGooglePlaySubscriptionMock
   .mockReset();
 });
@@ -212,6 +223,7 @@ describe('GET /billing/my-plan', () => {
         isFree: true,
         status: 'INACTIVE',
         renewsAt: null,
+        autoRenewEnabled: false,
         provider: null,
       },
     });
@@ -221,6 +233,10 @@ describe('GET /billing/my-plan', () => {
     const app = buildApp();
 
     const renewsAt = new Date('2026-01-01T00:00:00.000Z');
+
+    getEffectiveAppEntitlementMock.mockResolvedValue({
+      autoRenewEnabled: true,
+    });
 
     prismaMock.user.findUnique.mockResolvedValue({
       plan: 'PREMIUM',
@@ -252,6 +268,7 @@ describe('GET /billing/my-plan', () => {
         isFree: false,
         status: 'ACTIVE',
         renewsAt: renewsAt.toISOString(),
+        autoRenewEnabled: true,
         provider: 'STRIPE',
       },
     });

--- a/server/routes/billing.js
+++ b/server/routes/billing.js
@@ -5,6 +5,7 @@ import { getAddonConfig } from '../utils/billingProducts.js';
 import { verifyAndApplyGooglePlaySubscription } from '../services/googlePlayEntitlementService.js';
 import {
   assertAppSubscriptionProviderAvailable,
+  getEffectiveAppEntitlement,
   recomputeUserAppEntitlement,
 } from '../services/appEntitlementService.js';
 import { verifyAndApplyAppleSubscription } from '../services/appleEntitlementService.js';
@@ -294,6 +295,7 @@ router.get('/my-plan', async (req, res) => {
           isFree: true,
           status: 'INACTIVE',
           renewsAt: null,
+          autoRenewEnabled: false,
           provider: null,
         },
       });
@@ -309,6 +311,9 @@ router.get('/my-plan', async (req, res) => {
       },
     });
 
+    const entitlement =
+      await getEffectiveAppEntitlement(userId);
+
     const code = normalizePlanCode(user?.plan || 'FREE');
 
     return res.json({
@@ -321,6 +326,8 @@ router.get('/my-plan', async (req, res) => {
         renewsAt: user?.subscriptionEndsAt
           ? new Date(user.subscriptionEndsAt).toISOString()
           : null,
+        autoRenewEnabled:
+          Boolean(entitlement?.autoRenewEnabled),
         provider: user?.billingProvider || null,
       },
     });


### PR DESCRIPTION
## Summary
- expose `autoRenewEnabled` from `/billing/my-plan`
- show **Renews on** for auto-renewing subscriptions
- show **Active through** for subscriptions canceled at period end
- update both My Plan and Profile → My plan
- add server and client coverage for the new behavior

## Validation
- server billing tests: 25/25 passed with coverage disabled
- client MyPlan tests: 5/5 passed
- production client build completed successfully with a larger Node heap
