### PR TITLE
Resolve premium eSIM pricing aliases

### DIFF
--- a/server/__tests__/pricing.test.js
+++ b/server/__tests__/pricing.test.js
@@ -104,6 +104,103 @@ describe('GET /pricing/quote', () => {
     });
   });
 
+  it('resolves premium eSIM product aliases through existing pricing rows', async () => {
+    mockRegionRuleFindUnique.mockResolvedValueOnce(null);
+
+    mockPriceFindUnique.mockResolvedValueOnce({
+      product:
+        'chatforia_esim_local_3',
+
+      tier:
+        'ROW',
+
+      currency:
+        'USD',
+
+      unitAmount:
+        1499,
+
+      active:
+        true,
+
+      stripePriceId:
+        'price_esim_local_3',
+
+      appleSku:
+        null,
+
+      googleSku:
+        null,
+    });
+
+    const app = createApp();
+
+    const res =
+      await request(app)
+        .get('/pricing/quote')
+        .query({
+          country:
+            'US',
+
+          currency:
+            'USD',
+
+          product:
+            'chatforia_esim_local_3_premium',
+        });
+
+    expect(
+      res.statusCode
+    ).toBe(200);
+
+    expect(
+      res.body
+    ).toMatchObject({
+      product:
+        'chatforia_esim_local_3_premium',
+
+      country:
+        'US',
+
+      regionTier:
+        'ROW',
+
+      currency:
+        'USD',
+
+      unitAmount:
+        1499,
+
+      stripePriceId:
+        'price_esim_local_3',
+
+      display: {
+        amount:
+          '14.99',
+
+        currency:
+          'USD',
+      },
+    });
+
+    expect(
+      mockPriceFindUnique
+    ).toHaveBeenCalledWith({
+      where: {
+        product_tier_currency: {
+          product:
+            'chatforia_esim_local_3',
+
+          tier:
+            'ROW',
+
+          currency:
+            'USD',
+        },
+      },
+    });
+  });
+
   it('uses user billingCountry, pricingRegion, and currency when query params are missing', async () => {
     const user = {
       billingCountry: 'CA',

--- a/server/routes/pricing.js
+++ b/server/routes/pricing.js
@@ -22,6 +22,31 @@ function pickCurrencyForCountry(country) {
   return COUNTRY_CURRENCY[cc] || 'USD';
 }
 
+function normalizePricingProductForLookup(product) {
+  const normalized = String(product || '')
+    .trim()
+    .replace(
+      /_(\d+)gb(?=(_premium|_standard)?$)/i,
+      '_$1'
+    )
+    .replace(
+      /(\d+)gb$/i,
+      '$1'
+    );
+
+  if (
+    normalized.startsWith('chatforia_esim_') &&
+    normalized.endsWith('_premium')
+  ) {
+    return normalized.slice(
+      0,
+      -'_premium'.length
+    );
+  }
+
+  return normalized;
+}
+
 async function tierForCountry(country) {
   const cc = (country || '').toUpperCase();
   if (!cc) return 'ROW';
@@ -33,7 +58,17 @@ async function tierForCountry(country) {
 router.get('/quote', async (req, res) => {
   try {
     const user = req.user || null; // if you attach user on auth middleware
-    const product = (req.query.product || 'chatforia_premium').toString();
+
+    const requestedProduct =
+      (
+        req.query.product ||
+        'chatforia_premium'
+      ).toString();
+
+    const lookupProduct =
+      normalizePricingProductForLookup(
+        requestedProduct
+      );
 
     // Evidence (ordered by trust)
     const qCountry = (req.query.country || '').toString().toUpperCase();
@@ -60,20 +95,38 @@ router.get('/quote', async (req, res) => {
 
     // 4) Look up active price row
     let price = await prisma.price.findUnique({
-      where: { product_tier_currency: { product, tier, currency } },
+      where: {
+        product_tier_currency: {
+          product: lookupProduct,
+          tier,
+          currency,
+        },
+      },
     });
 
     // fallback 1: same tier in USD
     if (!price && currency !== 'USD') {
       price = await prisma.price.findUnique({
-        where: { product_tier_currency: { product, tier, currency: 'USD' } },
+        where: {
+          product_tier_currency: {
+            product: lookupProduct,
+            tier,
+            currency: 'USD',
+          },
+        },
       });
     }
 
     // fallback 2: ROW/USD
     if (!price) {
       price = await prisma.price.findUnique({
-        where: { product_tier_currency: { product, tier: 'ROW', currency: 'USD' } },
+        where: {
+          product_tier_currency: {
+            product: lookupProduct,
+            tier: 'ROW',
+            currency: 'USD',
+          },
+        },
       });
     }
 
@@ -83,7 +136,7 @@ router.get('/quote', async (req, res) => {
 
     // Shape response for client
     return res.json({
-      product,
+      product: requestedProduct,
       country,
       regionTier: tier,
       currency: price.currency,


### PR DESCRIPTION
## Summary
- normalize premium eSIM product ids to existing pricing rows
- preserve the originally requested product id in quote responses
- support `gb` suffix normalization without merging standard-tier ids into premium pricing
- add regression coverage for premium eSIM pricing aliases

## Validation
- pricing.test.js: 8 passed, 8 total
- git diff --check passed