### PR TITLE
feat: add device replacement workflow

### DIFF
--- a/server/__tests__/devices.test.js
+++ b/server/__tests__/devices.test.js
@@ -3,9 +3,13 @@ import express from 'express';
 import request from 'supertest';
 
 const prismaMock = {
+  $transaction: jest.fn(),
   device: {
-    count: jest.fn(),
+    findMany: jest.fn(),
+    updateMany: jest.fn(),
     upsert: jest.fn(),
+    findUnique: jest.fn(),
+    update: jest.fn(),
   },
   user: {
     findUnique: jest.fn(),
@@ -20,12 +24,17 @@ await jest.unstable_mockModule('../utils/prismaClient.js', () => ({
 await jest.unstable_mockModule('../middleware/auth.js', () => ({
   __esModule: true,
   requireAuth: (req, _res, next) => {
-    req.user = { id: 1, role: 'USER' };
+    req.user = {
+      id: 1,
+      role: 'USER',
+    };
+
     next();
   },
 }));
 
-const { default: devicesRouter } = await import('../routes/devices.js');
+const { default: devicesRouter } =
+  await import('../routes/devices.js');
 
 function makeApp() {
   const app = express();
@@ -41,66 +50,324 @@ function makeApp() {
   return app;
 }
 
-describe('Device limit', () => {
+function makeDevice(overrides = {}) {
+  return {
+    id: 'database-device-1',
+    userId: 1,
+    deviceId: 'device-new',
+    name: 'Android Device',
+    platform: 'Android',
+    publicKey: 'mock-public-key',
+    keyAlgorithm: 'curve25519',
+    keyVersion: 1,
+    isPrimary: false,
+    lastSeenAt: new Date('2026-07-20T20:00:00.000Z'),
+    createdAt: new Date('2026-07-20T20:00:00.000Z'),
+    updatedAt: new Date('2026-07-20T20:00:00.000Z'),
+    revokedAt: null,
+    ...overrides,
+  };
+}
+
+describe('Device registration and replacement', () => {
   let app;
 
   beforeEach(() => {
+    jest.resetAllMocks();
+
     app = makeApp();
 
-    jest.clearAllMocks();
+    prismaMock.$transaction.mockImplementation(
+      async (callback) => callback(prismaMock)
+    );
 
     prismaMock.user.findUnique.mockResolvedValue({
       plan: 'FREE',
     });
   });
 
-  test('second device for FREE returns 402', async () => {
-    prismaMock.device.count
-      .mockResolvedValueOnce(0)
-      .mockResolvedValueOnce(1);
+  test('FREE user registers when no active device exists', async () => {
+    prismaMock.device.findMany.mockResolvedValue([]);
 
-    prismaMock.device.upsert.mockResolvedValueOnce({
-      id: 1,
-      userId: 1,
-      deviceId: 'device-laptop',
-      name: 'Laptop',
-      platform: 'Web',
-      publicKey: 'mock-public-key-1',
-      keyAlgorithm: 'curve25519',
-      keyVersion: 1,
-      isPrimary: false,
-      lastSeenAt: new Date(),
-      createdAt: new Date(),
-      updatedAt: new Date(),
+    prismaMock.device.upsert.mockResolvedValue(
+      makeDevice()
+    );
+
+    const response = await request(app)
+      .post('/devices/register')
+      .send({
+        deviceId: 'device-new',
+        name: 'Android Device',
+        platform: 'Android',
+        publicKey: 'mock-public-key',
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body.device.deviceId).toBe('device-new');
+    expect(response.body.replacedDeviceIds).toEqual([]);
+
+    expect(prismaMock.device.updateMany).not.toHaveBeenCalled();
+    expect(prismaMock.device.upsert).toHaveBeenCalledTimes(1);
+  });
+
+  test('FREE reinstall requires replacement confirmation', async () => {
+    prismaMock.device.findMany.mockResolvedValue([
+      {
+        deviceId: 'device-old',
+        name: 'Old Android Device',
+        platform: 'Android',
+        lastSeenAt: new Date('2026-07-19T20:00:00.000Z'),
+        createdAt: new Date('2026-07-18T20:00:00.000Z'),
+      },
+    ]);
+
+    const response = await request(app)
+      .post('/devices/register')
+      .send({
+        deviceId: 'device-new',
+        name: 'Android Device',
+        platform: 'Android',
+        publicKey: 'mock-public-key',
+      });
+
+    expect(response.status).toBe(409);
+    expect(response.body.code).toBe(
+      'DEVICE_REPLACEMENT_REQUIRED'
+    );
+
+    expect(response.body.existingDevices).toEqual([
+      expect.objectContaining({
+        deviceId: 'device-old',
+        name: 'Old Android Device',
+        platform: 'Android',
+      }),
+    ]);
+
+    expect(prismaMock.device.updateMany).not.toHaveBeenCalled();
+    expect(prismaMock.device.upsert).not.toHaveBeenCalled();
+  });
+
+  test('confirmed FREE replacement revokes old device and registers new one', async () => {
+    prismaMock.device.findMany.mockResolvedValue([
+      {
+        deviceId: 'device-old',
+        name: 'Old Android Device',
+        platform: 'Android',
+        lastSeenAt: new Date('2026-07-19T20:00:00.000Z'),
+        createdAt: new Date('2026-07-18T20:00:00.000Z'),
+      },
+    ]);
+
+    prismaMock.device.updateMany.mockResolvedValue({
+      count: 1,
+    });
+
+    prismaMock.device.upsert.mockResolvedValue(
+      makeDevice()
+    );
+
+    const response = await request(app)
+      .post('/devices/register')
+      .send({
+        deviceId: 'device-new',
+        name: 'Android Device',
+        platform: 'Android',
+        publicKey: 'mock-public-key',
+        replaceExistingDevice: true,
+        replaceDeviceId: 'device-old',
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body.device.deviceId).toBe('device-new');
+    expect(response.body.replacedDeviceIds).toEqual([
+      'device-old',
+    ]);
+
+    expect(prismaMock.device.updateMany).toHaveBeenCalledWith({
+      where: {
+        userId: 1,
+        deviceId: {
+          not: 'device-new',
+        },
+        revokedAt: null,
+      },
+      data: expect.objectContaining({
+        revokedById: 1,
+        pushToken: null,
+        pushProvider: null,
+        apnsPushToken: null,
+        fcmPushToken: null,
+        voipPushToken: null,
+      }),
+    });
+
+    expect(prismaMock.device.upsert).toHaveBeenCalledTimes(1);
+  });
+
+  test('stale replacement target is rejected', async () => {
+    prismaMock.device.findMany.mockResolvedValue([
+      {
+        deviceId: 'device-current',
+        name: 'Current Device',
+        platform: 'Android',
+        lastSeenAt: new Date('2026-07-20T20:00:00.000Z'),
+        createdAt: new Date('2026-07-20T19:00:00.000Z'),
+      },
+    ]);
+
+    const response = await request(app)
+      .post('/devices/register')
+      .send({
+        deviceId: 'device-new',
+        name: 'Android Device',
+        platform: 'Android',
+        publicKey: 'mock-public-key',
+        replaceExistingDevice: true,
+        replaceDeviceId: 'device-no-longer-active',
+      });
+
+    expect(response.status).toBe(409);
+    expect(response.body.code).toBe(
+      'DEVICE_REPLACEMENT_TARGET_STALE'
+    );
+
+    expect(prismaMock.device.updateMany).not.toHaveBeenCalled();
+    expect(prismaMock.device.upsert).not.toHaveBeenCalled();
+  });
+
+  test('paid user can add another device without replacement', async () => {
+    prismaMock.user.findUnique.mockResolvedValue({
+      plan: 'PREMIUM',
+    });
+
+    prismaMock.device.findMany.mockResolvedValue([
+      {
+        deviceId: 'device-existing',
+        name: 'Existing Device',
+        platform: 'iOS',
+        lastSeenAt: new Date('2026-07-20T20:00:00.000Z'),
+        createdAt: new Date('2026-07-19T20:00:00.000Z'),
+      },
+    ]);
+
+    prismaMock.device.upsert.mockResolvedValue(
+      makeDevice()
+    );
+
+    const response = await request(app)
+      .post('/devices/register')
+      .send({
+        deviceId: 'device-new',
+        name: 'Android Device',
+        platform: 'Android',
+        publicKey: 'mock-public-key',
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body.replacedDeviceIds).toEqual([]);
+
+    expect(prismaMock.device.updateMany).not.toHaveBeenCalled();
+    expect(prismaMock.device.upsert).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('Push-token registration', () => {
+  let app;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    app = makeApp();
+  });
+
+  test('unregistered device cannot register a push token', async () => {
+    prismaMock.device.findUnique.mockResolvedValue(null);
+
+    const response = await request(app)
+      .post('/devices/push-token')
+      .send({
+        deviceId: 'device-new',
+        pushToken: 'mock-fcm-token',
+        pushProvider: 'fcm',
+      });
+
+    expect(response.status).toBe(409);
+    expect(response.body.code).toBe(
+      'DEVICE_REGISTRATION_REQUIRED'
+    );
+
+    expect(prismaMock.device.update).not.toHaveBeenCalled();
+  });
+
+  test('revoked device cannot register a push token', async () => {
+    prismaMock.device.findUnique.mockResolvedValue({
+      id: 'database-device-old',
+      revokedAt: new Date('2026-07-20T20:00:00.000Z'),
+    });
+
+    const response = await request(app)
+      .post('/devices/push-token')
+      .send({
+        deviceId: 'device-old',
+        pushToken: 'mock-fcm-token',
+        pushProvider: 'fcm',
+      });
+
+    expect(response.status).toBe(409);
+    expect(response.body.code).toBe('DEVICE_REVOKED');
+
+    expect(prismaMock.device.update).not.toHaveBeenCalled();
+  });
+
+  test('active device can update its FCM token without changing revokedAt', async () => {
+    prismaMock.device.findUnique.mockResolvedValue({
+      id: 'database-device-1',
       revokedAt: null,
     });
 
-    const first = await request(app).post('/devices/register').send({
-      deviceId: 'device-laptop',
-      name: 'Laptop',
-      platform: 'Web',
-      publicKey: 'mock-public-key-1',
+    prismaMock.device.update.mockResolvedValue({
+      id: 'database-device-1',
+      userId: 1,
+      deviceId: 'device-new',
+      name: 'Android Device',
+      platform: 'Android',
+      lastSeenAt: new Date('2026-07-20T20:00:00.000Z'),
+      updatedAt: new Date('2026-07-20T20:00:00.000Z'),
+      revokedAt: null,
+      pushToken: 'mock-fcm-token',
+      pushProvider: 'fcm',
+      apnsPushToken: null,
+      fcmPushToken: 'mock-fcm-token',
+      voipPushToken: null,
     });
 
-    expect(first.status).toBe(200);
+    const response = await request(app)
+      .post('/devices/push-token')
+      .send({
+        deviceId: 'device-new',
+        pushToken: 'mock-fcm-token',
+        pushProvider: 'fcm',
+      });
 
-    expect(prismaMock.device.upsert).toHaveBeenCalledTimes(1);
+    expect(response.status).toBe(200);
+    expect(response.body.success).toBe(true);
 
-    const second = await request(app).post('/devices/register').send({
-      deviceId: 'device-desktop',
-      name: 'Desktop',
-      platform: 'Web',
-      publicKey: 'mock-public-key-2',
+    expect(prismaMock.device.update).toHaveBeenCalledWith({
+      where: {
+        id: 'database-device-1',
+      },
+      data: {
+        lastSeenAt: expect.any(Date),
+        fcmPushToken: 'mock-fcm-token',
+        pushToken: 'mock-fcm-token',
+        pushProvider: 'fcm',
+      },
+      select: expect.any(Object),
     });
 
-    expect(second.status).toBe(402);
+    const updateCall =
+      prismaMock.device.update.mock.calls[0][0];
 
-    expect(second.body).toEqual({
-      error: 'FREE plan allows one active device. Upgrade to add more devices.',
-      code: 'DEVICE_LIMIT_REACHED',
-    });
-
-    expect(prismaMock.device.count).toHaveBeenCalledTimes(2);
-    expect(prismaMock.device.upsert).toHaveBeenCalledTimes(1);
+    expect(updateCall.data).not.toHaveProperty('revokedAt');
+    expect(updateCall.data).not.toHaveProperty('revokedById');
   });
 });

--- a/server/routes/devices.js
+++ b/server/routes/devices.js
@@ -46,7 +46,6 @@ const deviceSelect = {
 };
 
 router.post('/register', requireAuth, async (req, res, next) => {
-
   try {
     const userId = Number(req.user.id);
 
@@ -54,89 +53,226 @@ router.post('/register', requireAuth, async (req, res, next) => {
     const name = normalizeString(req.body?.name, 120) || 'iPhone';
     const platform = normalizeString(req.body?.platform, 120) || 'iOS';
     const publicKey = normalizeString(req.body?.publicKey, 4096);
-    const keyAlgorithm = normalizeString(req.body?.keyAlgorithm, 50) || 'curve25519';
+    const keyAlgorithm =
+      normalizeString(req.body?.keyAlgorithm, 50) || 'curve25519';
     const keyVersion = Number(req.body?.keyVersion || 1);
 
+    const replaceExistingDevice =
+      req.body?.replaceExistingDevice === true;
+
+    const replaceDeviceId =
+      normalizeString(req.body?.replaceDeviceId, 191);
+
     if (!userId || !deviceId || !publicKey) {
-  return res.status(400).json({ error: 'deviceId and publicKey are required' });
-}
-
-    const existingActiveDevices = await prisma.device.count({
-      where: {
-        userId,
-        revokedAt: null,
-        NOT: {
-          deviceId,
-        },
-      },
-    });
-
-    const user = await prisma.user.findUnique({
-      where: { id: userId },
-      select: {
-        plan: true,
-      },
-    });
-
-    const plan = String(user?.plan || 'FREE').toUpperCase();
-    const isPaidPlan = ['PLUS', 'PREMIUM', 'WIRELESS'].includes(plan);
-
-    if (!isPaidPlan && existingActiveDevices >= 1) {
-      return res.status(402).json({
-        error: 'FREE plan allows one active device. Upgrade to add more devices.',
-        code: 'DEVICE_LIMIT_REACHED',
+      return res.status(400).json({
+        error: 'deviceId and publicKey are required',
       });
     }
 
-    const device = await prisma.device.upsert({
-      where: {
-        userId_deviceId: {
+    if (replaceExistingDevice && !replaceDeviceId) {
+      return res.status(400).json({
+        error: 'replaceDeviceId is required when replacing a device',
+        code: 'REPLACE_DEVICE_ID_REQUIRED',
+      });
+    }
+
+    const result = await prisma.$transaction(async (tx) => {
+      const user = await tx.user.findUnique({
+        where: { id: userId },
+        select: {
+          plan: true,
+        },
+      });
+
+      if (!user) {
+        return {
+          status: 404,
+          body: {
+            error: 'User not found',
+            code: 'USER_NOT_FOUND',
+          },
+        };
+      }
+
+      const plan = String(user.plan || 'FREE').toUpperCase();
+      const isPaidPlan =
+        ['PLUS', 'PREMIUM', 'WIRELESS'].includes(plan);
+
+      const activeOtherDevices = await tx.device.findMany({
+        where: {
+          userId,
+          revokedAt: null,
+          NOT: {
+            deviceId,
+          },
+        },
+        orderBy: [
+          {
+            lastSeenAt: 'desc',
+          },
+          {
+            createdAt: 'desc',
+          },
+        ],
+        select: {
+          deviceId: true,
+          name: true,
+          platform: true,
+          lastSeenAt: true,
+          createdAt: true,
+        },
+      });
+
+      const activeDeviceSummaries =
+        activeOtherDevices.map((device) => ({
+          deviceId: device.deviceId,
+          name: device.name,
+          platform: device.platform,
+          lastSeenAt: device.lastSeenAt,
+          createdAt: device.createdAt,
+        }));
+
+      if (
+        !isPaidPlan &&
+        activeOtherDevices.length >= 1 &&
+        !replaceExistingDevice
+      ) {
+        return {
+          status: 409,
+          body: {
+            error:
+              'This plan allows one active device. Confirm which existing device should be replaced.',
+            code: 'DEVICE_REPLACEMENT_REQUIRED',
+            existingDevices: activeDeviceSummaries,
+          },
+        };
+      }
+
+      if (replaceExistingDevice) {
+        const replacementTarget =
+          activeOtherDevices.find(
+            (device) => device.deviceId === replaceDeviceId
+          );
+
+        if (!replacementTarget) {
+          return {
+            status: 409,
+            body: {
+              error:
+                'The selected replacement device is no longer active. Refresh the device list and try again.',
+              code: 'DEVICE_REPLACEMENT_TARGET_STALE',
+              existingDevices: activeDeviceSummaries,
+            },
+          };
+        }
+
+        const now = new Date();
+
+        const replacementWhere = isPaidPlan
+          ? {
+              userId,
+              deviceId: replaceDeviceId,
+              revokedAt: null,
+            }
+          : {
+              userId,
+              deviceId: {
+                not: deviceId,
+              },
+              revokedAt: null,
+            };
+
+        await tx.device.updateMany({
+          where: replacementWhere,
+          data: {
+            revokedAt: now,
+            revokedById: userId,
+            isPrimary: false,
+            pushToken: null,
+            pushProvider: null,
+            apnsPushToken: null,
+            fcmPushToken: null,
+            voipPushToken: null,
+          },
+        });
+      }
+
+      const device = await tx.device.upsert({
+        where: {
+          userId_deviceId: {
+            userId,
+            deviceId,
+          },
+        },
+        update: {
+          name,
+          platform,
+          publicKey,
+          keyAlgorithm,
+          keyVersion: Number.isFinite(keyVersion)
+            ? keyVersion
+            : 1,
+          lastSeenAt: new Date(),
+          revokedAt: null,
+          revokedById: null,
+          pairingStatus: 'approved',
+          pairingApprovedAt: new Date(),
+          pairingRejectedAt: null,
+        },
+        create: {
           userId,
           deviceId,
+          name,
+          platform,
+          publicKey,
+          keyAlgorithm,
+          keyVersion: Number.isFinite(keyVersion)
+            ? keyVersion
+            : 1,
+          lastSeenAt: new Date(),
+          pairingStatus: 'approved',
+          pairingApprovedAt: new Date(),
         },
-      },
-      update: {
-        name,
-        platform,
-        publicKey,
-        keyAlgorithm,
-        keyVersion: Number.isFinite(keyVersion) ? keyVersion : 1,
-        lastSeenAt: new Date(),
-        revokedAt: null,
-        pairingStatus: 'approved',
-        pairingApprovedAt: new Date(),
-        pairingRejectedAt: null,
-      },
-      create: {
-        userId,
-        deviceId,
-        name,
-        platform,
-        publicKey,
-        keyAlgorithm,
-        keyVersion: Number.isFinite(keyVersion) ? keyVersion : 1,
-        lastSeenAt: new Date(),
-        pairingStatus: 'approved',
-        pairingApprovedAt: new Date(),
-      },
-      select: {
-        id: true,
-        userId: true,
-        deviceId: true,
-        name: true,
-        platform: true,
-        publicKey: true,
-        keyAlgorithm: true,
-        keyVersion: true,
-        isPrimary: true,
-        lastSeenAt: true,
-        createdAt: true,
-        updatedAt: true,
-        revokedAt: true,
-      },
+        select: {
+          id: true,
+          userId: true,
+          deviceId: true,
+          name: true,
+          platform: true,
+          publicKey: true,
+          keyAlgorithm: true,
+          keyVersion: true,
+          isPrimary: true,
+          lastSeenAt: true,
+          createdAt: true,
+          updatedAt: true,
+          revokedAt: true,
+        },
+      });
+
+      const replacedDeviceIds =
+        replaceExistingDevice
+          ? isPaidPlan
+            ? [replaceDeviceId]
+            : activeOtherDevices.map(
+                (item) => item.deviceId
+              )
+          : [];
+
+      return {
+        device,
+        replacedDeviceIds,
+      };
     });
 
-    return res.status(200).json({ device });
+    if (result.status) {
+      return res.status(result.status).json(result.body);
+    }
+
+    return res.status(200).json({
+      device: result.device,
+      replacedDeviceIds: result.replacedDeviceIds,
+    });
   } catch (error) {
     next(error);
   }
@@ -471,41 +607,17 @@ router.post('/push-token', requireAuth, async (req, res) => {
   const userId = Number(req.user?.id);
   const deviceId = normalizeString(req.body?.deviceId, 191);
   const pushToken = normalizeString(req.body?.pushToken, 4096);
+
   const pushProvider =
-    (normalizeString(req.body?.pushProvider, 64) || 'apns').toLowerCase();
-  const pushTokenData = {
-    lastSeenAt: new Date(),
-    revokedAt: null,
-  };
-
-  if (pushProvider === 'apns_voip') {
-    pushTokenData.voipPushToken = pushToken;
-    pushTokenData.pushProvider = 'apns_voip';
-  } else if (pushProvider === 'apns') {
-    pushTokenData.apnsPushToken = pushToken;
-    pushTokenData.pushToken = pushToken;
-    pushTokenData.pushProvider = pushProvider;
-  } else if (pushProvider === 'fcm') {
-    pushTokenData.fcmPushToken = pushToken;
-    pushTokenData.pushToken = pushToken;
-    pushTokenData.pushProvider = pushProvider;
-  } else {
-    pushTokenData.pushToken = pushToken;
-    pushTokenData.pushProvider = pushProvider;
-  }
-
-  const publicKey = normalizeString(req.body?.publicKey, 4096);
-  const keyAlgorithm = normalizeString(req.body?.keyAlgorithm, 64) || 'curve25519';
-  const keyVersion = Number(req.body?.keyVersion || 1);
-  const platform =
-    normalizeString(req.body?.platform, 64) ||
-    (pushProvider === 'fcm' ? 'Android' : 'iOS');
-  const name =
-    normalizeString(req.body?.name, 191) ||
-    (pushProvider === 'fcm' ? 'Android device' : 'iOS device');
+    (
+      normalizeString(req.body?.pushProvider, 64) ||
+      'apns'
+    ).toLowerCase();
 
   if (!userId || !deviceId || !pushToken) {
-    return res.status(400).json({ error: 'deviceId and pushToken are required' });
+    return res.status(400).json({
+      error: 'deviceId and pushToken are required',
+    });
   }
 
   try {
@@ -516,72 +628,74 @@ router.post('/push-token', requireAuth, async (req, res) => {
           deviceId,
         },
       },
+      select: {
+        id: true,
+        revokedAt: true,
+      },
     });
 
-    let device;
-
-    if (existing) {
-      device = await prisma.device.update({
-        where: {
-          userId_deviceId: {
-            userId,
-            deviceId,
-          },
-        },
-        data: pushTokenData,
-        select: {
-          id: true,
-          userId: true,
-          deviceId: true,
-          name: true,
-          platform: true,
-          lastSeenAt: true,
-          updatedAt: true,
-          revokedAt: true,
-          pushToken: true,
-          pushProvider: true,
-          apnsPushToken: true,
-          fcmPushToken: true,
-          voipPushToken: true,
-        },
-      });
-    } else {
-      if (!publicKey) {
-        return res.status(400).json({
-          error: 'publicKey is required when creating a new device from push-token',
-        });
-      }
-
-      device = await prisma.device.create({
-        data: {
-          userId,
-          deviceId,
-          ...pushTokenData,
-          publicKey,
-          keyAlgorithm,
-          keyVersion,
-          platform,
-          name,
-        },
-        select: {
-          id: true,
-          userId: true,
-          deviceId: true,
-          name: true,
-          platform: true,
-          lastSeenAt: true,
-          updatedAt: true,
-          revokedAt: true,
-          pushToken: true,
-          pushProvider: true,
-          apnsPushToken: true,
-          fcmPushToken: true,
-          voipPushToken: true,
-        },
+    if (!existing) {
+      return res.status(409).json({
+        error:
+          'Register this device before registering its push token.',
+        code: 'DEVICE_REGISTRATION_REQUIRED',
       });
     }
 
-    return res.json({ success: true, device });
+    if (existing.revokedAt) {
+      return res.status(409).json({
+        error:
+          'This device has been revoked and cannot register a push token.',
+        code: 'DEVICE_REVOKED',
+      });
+    }
+
+    const pushTokenData = {
+      lastSeenAt: new Date(),
+    };
+
+    if (pushProvider === 'apns_voip') {
+      pushTokenData.voipPushToken = pushToken;
+      pushTokenData.pushProvider = 'apns_voip';
+    } else if (pushProvider === 'apns') {
+      pushTokenData.apnsPushToken = pushToken;
+      pushTokenData.pushToken = pushToken;
+      pushTokenData.pushProvider = pushProvider;
+    } else if (pushProvider === 'fcm') {
+      pushTokenData.fcmPushToken = pushToken;
+      pushTokenData.pushToken = pushToken;
+      pushTokenData.pushProvider = pushProvider;
+    } else {
+      pushTokenData.pushToken = pushToken;
+      pushTokenData.pushProvider = pushProvider;
+    }
+
+    const device = await prisma.device.update({
+      where: {
+        id: existing.id,
+      },
+      data: pushTokenData,
+      select: {
+        id: true,
+        userId: true,
+        deviceId: true,
+        name: true,
+        platform: true,
+        lastSeenAt: true,
+        updatedAt: true,
+        revokedAt: true,
+        pushToken: true,
+        pushProvider: true,
+        apnsPushToken: true,
+        fcmPushToken: true,
+        voipPushToken: true,
+      },
+    });
+
+    return res.json({
+      success: true,
+      device,
+    });
   } catch (error) {
     console.error('❌ /devices/push-token failed', {
       userId,


### PR DESCRIPTION
## Summary

Adds the shared backend workflow for explicit device replacement across iOS and Android.

## Changes

- Returns `DEVICE_REPLACEMENT_REQUIRED` when registration exceeds the active-device limit
- Returns `DEVICE_REPLACEMENT_TARGET_STALE` when the selected replacement target is no longer valid
- Accepts `replaceExistingDevice` and `replaceDeviceId`
- Performs confirmed replacement inside a Prisma transaction
- Revokes replaced devices and clears their push tokens
- Registers the new installation after confirmed replacement
- Prevents `/devices/push-token` from creating or reactivating devices
- Returns `DEVICE_REGISTRATION_REQUIRED` for unregistered devices
- Returns `DEVICE_REVOKED` for revoked devices
- Adds focused registration, replacement, and push-token tests

## Verification

- `node --check server/routes/devices.js` succeeded
- 8 focused Jest tests passed
- No Prisma migration required
- `git diff --cached --check` passed