### PR TITLE
Fix Android eSIM checkout return flow

### DIFF
--- a/client/src/pages/MobileEsimCheckoutReturn.jsx
+++ b/client/src/pages/MobileEsimCheckoutReturn.jsx
@@ -37,17 +37,21 @@ export default function MobileEsimCheckoutReturn({
   const appURLString = appURL.toString();
 
   useEffect(() => {
+    const userAgent =
+      window.navigator.userAgent || '';
+
     const isIOS =
-      /iPad|iPhone|iPod/.test(
-        window.navigator.userAgent
-      ) ||
+      /iPad|iPhone|iPod/i.test(userAgent) ||
       (
         window.navigator.platform ===
           'MacIntel' &&
         window.navigator.maxTouchPoints > 1
       );
 
-    if (!isIOS) {
+    const isAndroid =
+      /Android/i.test(userAgent);
+
+    if (!isIOS && !isAndroid) {
       return undefined;
     }
 

--- a/server/routes/billing.js
+++ b/server/routes/billing.js
@@ -639,16 +639,17 @@ router.post('/checkout', async (req, res) => {
       process.env.WEB_URL ||
       'https://chatforia.com';
 
-    const isIOSAddonCheckout =
-      isAddon && platform === 'ios';
+    const isMobileAddonCheckout =
+      isAddon &&
+      ['ios', 'android'].includes(platform);
 
     const addonSuccessURL =
-      isIOSAddonCheckout
+      isMobileAddonCheckout
         ? `${frontendOrigin}/mobile/esim/checkout-complete?session_id={CHECKOUT_SESSION_ID}`
         : `${frontendOrigin}/account/esim?session_id={CHECKOUT_SESSION_ID}`;
 
     const addonCancelURL =
-      isIOSAddonCheckout
+      isMobileAddonCheckout
         ? `${frontendOrigin}/mobile/esim/checkout-canceled`
         : `${frontendOrigin}/upgrade?canceled=1`;
 


### PR DESCRIPTION
- Detect Android on the mobile eSIM checkout return page
- Reopen Chatforia after Android Stripe checkout
- Route Android eSIM success and cancellation through the mobile return pages