### PR TITLE
feat: add clickable message links and improve eSIM return flow

### DIFF
--- a/client/src/ads/AdSenseAutoAds.jsx
+++ b/client/src/ads/AdSenseAutoAds.jsx
@@ -13,6 +13,7 @@ const EXCLUDED_PREFIXES = [
   '/dialer',
   '/voicemail',
   '/pricing',
+  '/mobile/esim',
 ];
 
 function isPaidUser(user) {
@@ -38,13 +39,13 @@ export default function AdSenseAutoAds() {
     const adsEnabled = import.meta.env.VITE_ADS_ENABLED !== 'false';
 
     const isExcludedRoute = EXCLUDED_PREFIXES.some((prefix) =>
-    location.pathname.startsWith(prefix)
+      location.pathname.startsWith(prefix)
     );
 
     const shouldLoadAds =
-    adsEnabled &&
-    !isPaidUser(currentUser) &&
-    !isExcludedRoute;
+      adsEnabled &&
+      !isPaidUser(currentUser) &&
+      !isExcludedRoute;
     
     if (!shouldLoadAds) return;
 

--- a/client/src/components/chat/MessageBubble.jsx
+++ b/client/src/components/chat/MessageBubble.jsx
@@ -50,6 +50,55 @@ function messageHasDate(text = '') {
   return patterns.some((p) => p.test(t));
 }
 
+function LinkifiedText({ text }) {
+  const value = String(text || '');
+  const urlPattern =
+    /((?:https?:\/\/|www\.)[^\s<]+)/gi;
+
+  return value.split(urlPattern).map((part, index) => {
+    const isUrl =
+      /^(?:https?:\/\/|www\.)/i.test(part);
+
+    if (!isUrl) {
+      return part;
+    }
+
+    const match = part.match(
+      /^(.*?)([.,!?;:]*)$/
+    );
+
+    const visibleUrl = match?.[1] || part;
+    const trailingPunctuation = match?.[2] || '';
+
+    const href = /^www\./i.test(visibleUrl)
+      ? `https://${visibleUrl}`
+      : visibleUrl;
+
+    return (
+      <span key={`${visibleUrl}-${index}`}>
+        <a
+          href={href}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={(event) => {
+            event.stopPropagation();
+          }}
+          style={{
+            color: 'inherit',
+            textDecoration: 'underline',
+            textUnderlineOffset: 2,
+            overflowWrap: 'anywhere',
+          }}
+        >
+          {visibleUrl}
+        </a>
+
+        {trailingPunctuation}
+      </span>
+    );
+  });
+}
+
 export default function MessageBubble({
   msg,
   currentUserId,
@@ -380,7 +429,7 @@ export default function MessageBubble({
                     maxWidth: '100%',
                   }}
                 >
-                  {displayText}
+                    <LinkifiedText text={displayText} />
                   {Boolean(msg.editedAt) && !isTombstone ? (
                     <Text component="span" size="xs" ml={8} style={{ opacity: 0.85 }}>
                       (edited)
@@ -514,7 +563,7 @@ export default function MessageBubble({
                       fontStyle: isTombstone ? 'italic' : 'normal',
                     }}
                   >
-                    {displayText}
+                        <LinkifiedText text={displayText} />
                     {Boolean(msg.editedAt) && !isTombstone ? (
                       <Text component="span" size="xs" ml={8} style={{ opacity: 0.85 }}>
                         (edited)

--- a/client/src/pages/MobileEsimCheckoutReturn.jsx
+++ b/client/src/pages/MobileEsimCheckoutReturn.jsx
@@ -52,16 +52,10 @@ export default function MobileEsimCheckoutReturn({
       /Android/i.test(userAgent);
 
     if (!isIOS && !isAndroid) {
-      return undefined;
+      return;
     }
 
-    const timer = window.setTimeout(() => {
-      window.location.assign(appURLString);
-    }, 300);
-
-    return () => {
-      window.clearTimeout(timer);
-    };
+    window.location.assign(appURLString);
   }, [appURLString]);
 
   return (


### PR DESCRIPTION
## Summary

- Make web chat message URLs clickable
- Support links beginning with `https://`, `http://`, and `www.`
- Open message links safely in a new browser tab
- Make links in media captions clickable
- Exclude mobile eSIM checkout return pages from AdSense
- Remove the 300 ms delay before returning users to the Chatforia app

## Testing

- Ran `npm run build`
- Production build completed successfully
- Verified only the three intended client files are included