### PR TITLE
Add app-to-app voicemail fallback

### DIFF
--- a/server/__tests__/voiceWebhooks.test.js
+++ b/server/__tests__/voiceWebhooks.test.js
@@ -41,6 +41,7 @@ class MockVoiceResponse {
       type: 'dial',
       opts,
       numbers: [],
+      clients: [],
     };
 
     this.actions.push(dial);
@@ -48,6 +49,10 @@ class MockVoiceResponse {
     return {
       number: (to) => {
         dial.numbers.push({ to });
+        return this;
+      },
+      client: (to) => {
+        dial.clients.push({ to });
         return this;
       },
     };
@@ -453,6 +458,299 @@ describe('POST /webhooks/voice/inbound', () => {
 
     expect(actions[1].opts.action).toBe(
       '/webhooks/voice/voicemail-complete'
+    );
+  });
+});
+
+// -----------------------------------------------------------------------------
+// POST /webhooks/voice/client — app-to-app voicemail handoff
+// -----------------------------------------------------------------------------
+
+describe('POST /webhooks/voice/client app-to-app voicemail handoff', () => {
+  it('rings the Chatforia client for 25 seconds with a voicemail callback', async () => {
+    prisma.user.findUnique.mockResolvedValueOnce({
+      id: 99,
+    });
+
+    const app = createApp();
+
+    const res = await request(app)
+      .post('/webhooks/voice/client')
+      .type('form')
+      .send({
+        From: 'client:user_42',
+        To: '99',
+        backendCallId: '777',
+      });
+
+    expect(res.statusCode).toBe(200);
+
+    const actions = JSON.parse(res.text);
+
+    expect(actions).toHaveLength(1);
+    expect(actions[0].type).toBe('dial');
+    expect(actions[0].opts).toMatchObject({
+      answerOnBridge: true,
+      timeout: 25,
+      method: 'POST',
+    });
+    expect(actions[0].clients).toEqual([
+      {
+        to: 'user_99',
+      },
+    ]);
+
+    const completionUrl = new URL(
+      actions[0].opts.action,
+      'https://chatforia.test'
+    );
+
+    expect(completionUrl.pathname).toBe(
+      '/webhooks/voice/app-call-complete'
+    );
+    expect(completionUrl.searchParams.get('callerUserId')).toBe('42');
+    expect(completionUrl.searchParams.get('calleeUserId')).toBe('99');
+    expect(completionUrl.searchParams.get('backendCallId')).toBe('777');
+  });
+});
+
+// -----------------------------------------------------------------------------
+// POST /webhooks/voice/app-call-complete
+// -----------------------------------------------------------------------------
+
+describe('POST /webhooks/voice/app-call-complete', () => {
+  it('stops the unanswered recipient and sends the caller into voicemail', async () => {
+    prisma.call.findFirst.mockResolvedValueOnce({
+      id: 777,
+      callerId: 42,
+      calleeId: 99,
+      startedAt: null,
+    });
+
+    prisma.call.update.mockResolvedValueOnce({
+      id: 777,
+      callerId: 42,
+      calleeId: 99,
+      status: 'MISSED',
+      endedAt: new Date('2026-07-22T12:00:00.000Z'),
+      durationSec: 0,
+      endReason: 'no_answer',
+    });
+
+    prisma.user.findUnique
+      .mockResolvedValueOnce({
+        id: 99,
+        voicemailEnabled: true,
+        voicemailGreetingUrl: null,
+        voicemailGreetingText: 'Please leave Julian a message.',
+        assignedNumbers: [
+          {
+            id: 12,
+            e164: '+15550009999',
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        id: 42,
+        assignedNumbers: [
+          {
+            e164: '+15550004242',
+          },
+        ],
+      });
+
+    const app = createApp();
+
+    const res = await request(app)
+      .post(
+        '/webhooks/voice/app-call-complete' +
+          '?callerUserId=42' +
+          '&calleeUserId=99' +
+          '&backendCallId=777'
+      )
+      .type('form')
+      .send({
+        DialCallStatus: 'no-answer',
+        DialCallDuration: '0',
+      });
+
+    expect(res.statusCode).toBe(200);
+
+    const actions = JSON.parse(res.text);
+
+    expect(actions[0]).toEqual({
+      type: 'say',
+      opts: {},
+      text: 'Please leave Julian a message.',
+    });
+
+    const recordAction = actions.find(
+      (action) => action.type === 'record'
+    );
+
+    expect(recordAction).toBeDefined();
+    expect(recordAction.opts).toMatchObject({
+      playBeep: true,
+      maxLength: 120,
+      timeout: 5,
+      trim: 'trim-silence',
+      method: 'POST',
+      recordingStatusCallbackMethod: 'POST',
+    });
+
+    const completionUrl = new URL(
+      recordAction.opts.action,
+      'https://chatforia.test'
+    );
+
+    const recordingStatusUrl = new URL(
+      recordAction.opts.recordingStatusCallback,
+      'https://chatforia.test'
+    );
+
+    for (const callbackUrl of [completionUrl, recordingStatusUrl]) {
+      expect(callbackUrl.searchParams.get('userId')).toBe('99');
+      expect(callbackUrl.searchParams.get('phoneNumberId')).toBe('12');
+      expect(callbackUrl.searchParams.get('did')).toBe('+15550009999');
+      expect(callbackUrl.searchParams.get('from')).toBe('+15550004242');
+      expect(callbackUrl.searchParams.get('relatedCallId')).toBe('777');
+    }
+
+    expect(prisma.call.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          id: 777,
+        },
+        data: expect.objectContaining({
+          status: 'MISSED',
+          endReason: 'no_answer',
+        }),
+      })
+    );
+
+    expect(emitToUser).toHaveBeenCalledWith(
+      99,
+      'call:ended',
+      expect.objectContaining({
+        callId: 777,
+        status: 'MISSED',
+        reason: 'no_answer',
+      })
+    );
+
+    expect(emitToUser).not.toHaveBeenCalledWith(
+      42,
+      'call:ended',
+      expect.anything()
+    );
+  });
+});
+
+// -----------------------------------------------------------------------------
+// POST /webhooks/voice/app-call-complete — older client fallback
+// -----------------------------------------------------------------------------
+
+describe('POST /webhooks/voice/app-call-complete older client fallback', () => {
+  it('finds the latest matching audio call when backendCallId is absent', async () => {
+    prisma.call.findFirst.mockResolvedValueOnce({
+      id: 888,
+      callerId: 42,
+      calleeId: 99,
+      startedAt: null,
+    });
+
+    prisma.call.update.mockResolvedValueOnce({
+      id: 888,
+      callerId: 42,
+      calleeId: 99,
+      status: 'MISSED',
+      endedAt: new Date('2026-07-22T12:00:00.000Z'),
+      durationSec: 0,
+      endReason: 'no_answer',
+    });
+
+    prisma.user.findUnique
+      .mockResolvedValueOnce({
+        id: 99,
+        voicemailEnabled: true,
+        voicemailGreetingUrl: null,
+        voicemailGreetingText: 'Please leave a message.',
+        assignedNumbers: [
+          {
+            id: 12,
+            e164: '+15550009999',
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        id: 42,
+        assignedNumbers: [],
+      });
+
+    const app = createApp();
+
+    const res = await request(app)
+      .post(
+        '/webhooks/voice/app-call-complete' +
+          '?callerUserId=42' +
+          '&calleeUserId=99'
+      )
+      .type('form')
+      .send({
+        DialCallStatus: 'no-answer',
+        DialCallDuration: '0',
+      });
+
+    expect(res.statusCode).toBe(200);
+
+    expect(prisma.call.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          callerId: 42,
+          calleeId: 99,
+          mode: 'AUDIO',
+          status: {
+            in: ['INITIATED', 'RINGING', 'ACTIVE'],
+          },
+          createdAt: {
+            gte: expect.any(Date),
+          },
+        }),
+        orderBy: {
+          createdAt: 'desc',
+        },
+      })
+    );
+
+    expect(prisma.call.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          id: 888,
+        },
+      })
+    );
+
+    const actions = JSON.parse(res.text);
+    const recordAction = actions.find(
+      (action) => action.type === 'record'
+    );
+
+    expect(recordAction).toBeDefined();
+
+    const completionUrl = new URL(
+      recordAction.opts.action,
+      'https://chatforia.test'
+    );
+
+    expect(completionUrl.searchParams.get('relatedCallId')).toBe('888');
+
+    expect(emitToUser).toHaveBeenCalledWith(
+      99,
+      'call:ended',
+      expect.objectContaining({
+        callId: 888,
+        status: 'MISSED',
+      })
     );
   });
 });

--- a/server/routes/voiceWebhooks.js
+++ b/server/routes/voiceWebhooks.js
@@ -296,6 +296,273 @@ router.post('/inbound-app-complete', async (req, res) => {
 });
 
 
+
+router.post('/app-call-complete', async (req, res) => {
+  const twiml = new VoiceResponse();
+
+  try {
+    const dialCallStatus =
+      String(req.body?.DialCallStatus || '').toLowerCase();
+
+    const callerUserId = Number(req.query?.callerUserId);
+    const calleeUserId = Number(req.query?.calleeUserId);
+    const backendCallId = Number(req.query?.backendCallId);
+    const dialCallDuration = req.body?.DialCallDuration;
+
+    const validCallerUserId =
+      Number.isInteger(callerUserId) && callerUserId > 0;
+
+    const validCalleeUserId =
+      Number.isInteger(calleeUserId) && calleeUserId > 0;
+
+    const validBackendCallId =
+      Number.isInteger(backendCallId) && backendCallId > 0;
+
+    let relatedCallId = null;
+    let existing = null;
+
+    if (validBackendCallId) {
+      existing = await prisma.call.findFirst({
+        where: {
+          id: backendCallId,
+          ...(validCallerUserId ? { callerId: callerUserId } : {}),
+          ...(validCalleeUserId ? { calleeId: calleeUserId } : {}),
+        },
+        select: {
+          id: true,
+          callerId: true,
+          calleeId: true,
+          startedAt: true,
+        },
+      });
+    }
+
+    // Current clients should send backendCallId. This fallback keeps
+    // voicemail reliable for an older iOS or Android build that does not.
+    if (!existing && validCallerUserId && validCalleeUserId) {
+      const recentCutoff = new Date(Date.now() - 5 * 60 * 1000);
+
+      existing = await prisma.call.findFirst({
+        where: {
+          callerId: callerUserId,
+          calleeId: calleeUserId,
+          mode: 'AUDIO',
+          status: {
+            in: ['INITIATED', 'RINGING', 'ACTIVE'],
+          },
+          createdAt: {
+            gte: recentCutoff,
+          },
+        },
+        orderBy: {
+          createdAt: 'desc',
+        },
+        select: {
+          id: true,
+          callerId: true,
+          calleeId: true,
+          startedAt: true,
+        },
+      });
+    }
+
+    if (existing) {
+      let status = 'ENDED';
+      let endReason = 'completed';
+
+      if (dialCallStatus === 'no-answer') {
+        status = 'MISSED';
+        endReason = 'no_answer';
+      } else if (dialCallStatus === 'busy') {
+        status = 'FAILED';
+        endReason = 'busy';
+      } else if (dialCallStatus === 'failed') {
+        status = 'FAILED';
+        endReason = 'failed';
+      } else if (dialCallStatus === 'canceled') {
+        status = 'DECLINED';
+        endReason = 'canceled';
+      }
+
+      const endedAt = new Date();
+
+      const updated = await prisma.call.update({
+        where: { id: existing.id },
+        data: {
+          status,
+          startedAt:
+            dialCallStatus === 'completed'
+              ? existing.startedAt ?? endedAt
+              : existing.startedAt ?? undefined,
+          endedAt,
+          durationSec:
+            dialCallDuration != null
+              ? Number(dialCallDuration)
+              : undefined,
+          endReason,
+        },
+        select: {
+          id: true,
+          callerId: true,
+          calleeId: true,
+          status: true,
+          endedAt: true,
+          durationSec: true,
+          endReason: true,
+        },
+      });
+
+      relatedCallId = updated.id;
+
+      const endedPayload = {
+        callId: updated.id,
+        status: updated.status,
+        endedAt: updated.endedAt,
+        durationSec: updated.durationSec,
+        reason: updated.endReason,
+        forwarded: false,
+      };
+
+      // For voicemail, keep the caller connected to Twilio while ending
+      // the unanswered recipient's ringing state.
+      if (dialCallStatus === 'completed') {
+        emitToUser(updated.callerId, 'call:ended', endedPayload);
+      }
+
+      if (
+        updated.calleeId &&
+        updated.calleeId !== updated.callerId
+      ) {
+        emitToUser(updated.calleeId, 'call:ended', endedPayload);
+      }
+    }
+
+
+    if (dialCallStatus === 'completed') {
+      twiml.hangup();
+      return res.type('text/xml').send(twiml.toString());
+    }
+
+    const shouldOfferVoicemail = [
+      'no-answer',
+      'busy',
+      'failed',
+    ].includes(dialCallStatus);
+
+    if (!shouldOfferVoicemail || !validCalleeUserId) {
+      twiml.hangup();
+      return res.type('text/xml').send(twiml.toString());
+    }
+
+    const [callee, caller] = await Promise.all([
+      prisma.user.findUnique({
+        where: { id: calleeUserId },
+        select: {
+          id: true,
+          voicemailEnabled: true,
+          voicemailGreetingUrl: true,
+          voicemailGreetingText: true,
+          assignedNumbers: {
+            select: {
+              id: true,
+              e164: true,
+            },
+            take: 1,
+            orderBy: {
+              id: 'asc',
+            },
+          },
+        },
+      }),
+      validCallerUserId
+        ? prisma.user.findUnique({
+            where: { id: callerUserId },
+            select: {
+              id: true,
+              assignedNumbers: {
+                select: {
+                  e164: true,
+                },
+                take: 1,
+                orderBy: {
+                  id: 'asc',
+                },
+              },
+            },
+          })
+        : Promise.resolve(null),
+    ]);
+
+    if (!callee?.voicemailEnabled) {
+      twiml.say('The person you called is unavailable.');
+      twiml.hangup();
+      return res.type('text/xml').send(twiml.toString());
+    }
+
+    if (callee.voicemailGreetingUrl) {
+      twiml.play(callee.voicemailGreetingUrl);
+    } else if (callee.voicemailGreetingText?.trim()) {
+      twiml.say(callee.voicemailGreetingText.trim());
+    } else {
+      twiml.say(
+        'The person you called is unavailable. Please leave a message after the tone.'
+      );
+    }
+
+    const calleeNumber = callee.assignedNumbers?.[0] || null;
+    const callerNumber = caller?.assignedNumbers?.[0]?.e164 || null;
+
+    const did =
+      calleeNumber?.e164 ||
+      `app:user_${calleeUserId}`;
+
+    const from =
+      callerNumber ||
+      (validCallerUserId
+        ? `app:user_${callerUserId}`
+        : 'app:unknown');
+
+    const recordingParams = new URLSearchParams({
+      userId: String(calleeUserId),
+      phoneNumberId: String(calleeNumber?.id || ''),
+      did,
+      from,
+    });
+
+    if (relatedCallId) {
+      recordingParams.set(
+        'relatedCallId',
+        String(relatedCallId)
+      );
+    }
+
+    twiml.record({
+      playBeep: true,
+      maxLength: 120,
+      timeout: 5,
+      trim: 'trim-silence',
+      action:
+        `/webhooks/voice/voicemail/complete?` +
+        recordingParams.toString(),
+      method: 'POST',
+      recordingStatusCallback:
+        `/webhooks/voice/voicemail/recording-status?` +
+        recordingParams.toString(),
+      recordingStatusCallbackMethod: 'POST',
+    });
+
+    twiml.say('No recording received. Goodbye.');
+    twiml.hangup();
+
+    return res.type('text/xml').send(twiml.toString());
+  } catch (err) {
+    console.error('[Twilio Voice app-call-complete] error', err);
+    twiml.say('An error occurred. Goodbye.');
+    twiml.hangup();
+    return res.type('text/xml').send(twiml.toString());
+  }
+});
+
 router.post('/client', async (req, res) => {
   const twiml = new VoiceResponse();
 
@@ -324,7 +591,39 @@ router.post('/client', async (req, res) => {
         return res.type('text/xml').send(twiml.toString());
       }
 
-      const dial = twiml.dial();
+      const appCallerUserId =
+        identity.startsWith('user_')
+          ? Number(identity.slice('user_'.length))
+          : null;
+
+      const appBackendCallIdRaw =
+        req.query?.backendCallId ||
+        req.body?.backendCallId ||
+        null;
+
+      const appBackendCallId = appBackendCallIdRaw
+        ? Number(appBackendCallIdRaw)
+        : null;
+
+      const completionParams = new URLSearchParams({
+        calleeUserId: String(numericUserId),
+      });
+
+      if (Number.isInteger(appCallerUserId) && appCallerUserId > 0) {
+        completionParams.set('callerUserId', String(appCallerUserId));
+      }
+
+      if (Number.isInteger(appBackendCallId) && appBackendCallId > 0) {
+        completionParams.set('backendCallId', String(appBackendCallId));
+      }
+
+      const dial = twiml.dial({
+        answerOnBridge: true,
+        timeout: 25,
+        action: `/webhooks/voice/app-call-complete?${completionParams.toString()}`,
+        method: 'POST',
+      });
+
       dial.client(`user_${numericUserId}`);
 
       return res.type('text/xml').send(twiml.toString());

--- a/server/routes/webhooksTwilio.js
+++ b/server/routes/webhooksTwilio.js
@@ -239,7 +239,13 @@ r.post(
         RecordingStatus,
       } = req.body || {};
 
-      const { userId, phoneNumberId, did, from } = req.query || {};
+      const {
+        userId,
+        phoneNumberId,
+        did,
+        from,
+        relatedCallId,
+      } = req.query || {};
 
       if (!userId || !did || !from) {
         console.error('[voicemail] missing required query params');
@@ -263,20 +269,61 @@ r.post(
         return;
       }
 
-      const numericPhoneNumberId = phoneNumberId ? Number(phoneNumberId) : null;
+      const numericPhoneNumberId =
+        phoneNumberId ? Number(phoneNumberId) : null;
+
+      const numericRelatedCallId =
+        relatedCallId ? Number(relatedCallId) : null;
+
       const createdAt = new Date();
 
-      const matchingCall = await findMatchingMissedCall({
-        userId: numericUserId,
-        createdAt,
-      });
+      let matchingCall = null;
+
+      if (
+        Number.isInteger(numericRelatedCallId) &&
+        numericRelatedCallId > 0
+      ) {
+        matchingCall = await prisma.call.findFirst({
+          where: {
+            id: numericRelatedCallId,
+            OR: [
+              { callerId: numericUserId },
+              { calleeId: numericUserId },
+            ],
+          },
+          select: {
+            id: true,
+          },
+        });
+      }
+
+      if (!matchingCall) {
+        matchingCall = await findMatchingMissedCall({
+          userId: numericUserId,
+          createdAt,
+        });
+      }
+
+      const normalizedFrom = normalizeE164(String(from));
+      const normalizedDid = normalizeE164(String(did));
+
+      const storedFrom =
+        normalizedFrom || String(from || '').trim();
+
+      const storedTo =
+        normalizedDid || String(did || '').trim();
+
+      if (!storedFrom || !storedTo) {
+        console.error('[voicemail] invalid caller or destination');
+        return;
+      }
 
       const voicemail = await prisma.voicemail.create({
         data: {
           userId: numericUserId,
           phoneNumberId: Number.isNaN(numericPhoneNumberId) ? null : numericPhoneNumberId,
-          fromNumber: normalizeE164(String(from)),
-          toNumber: normalizeE164(String(did)),
+          fromNumber: storedFrom,
+          toNumber: storedTo,
           audioUrl: `${RecordingUrl}.mp3`,
           durationSec: RecordingDuration != null ? Number(RecordingDuration) : null,
           transcript: null,


### PR DESCRIPTION
## Summary

- Route unanswered app-to-app audio calls to voicemail after 25 seconds
- Support custom voicemail greeting text or audio
- Stop the unanswered recipient’s ringing state while keeping the caller connected to voicemail
- Associate recorded voicemail with the exact backend call
- Add a recent-call fallback for older iOS or Android clients that do not send backendCallId
- Preserve the existing PSTN voicemail recording flow

## Validation

- Prisma schema validation passed
- JavaScript syntax checks passed
- App-to-app voicemail tests: 3 passed
- Existing voicemail API tests: 5 passed
- git diff --check passed