### PR TITLE
Add secure voicemail audio playback

### DIFF
--- a/server/__tests__/voicemail.test.js
+++ b/server/__tests__/voicemail.test.js
@@ -9,6 +9,7 @@ import request from 'supertest';
 const prismaMock = {
   voicemail: {
     findMany: jest.fn(),
+    findFirst: jest.fn(),
     updateMany: jest.fn(),
   },
 };
@@ -17,6 +18,13 @@ const prismaMock = {
 jest.unstable_mockModule('../utils/prismaClient.js', () => ({
   __esModule: true,
   default: prismaMock,
+}));
+
+const fetchTwilioMediaMock = jest.fn();
+
+jest.unstable_mockModule('../utils/twilioMediaProxy.js', () => ({
+  __esModule: true,
+  fetchTwilioMedia: fetchTwilioMediaMock,
 }));
 
 jest.unstable_mockModule('../middleware/auth.js', () => ({
@@ -84,6 +92,72 @@ describe('voicemail routes', () => {
         createdAt: fakeVoicemails[1].createdAt.toISOString(),
       })
     );
+  });
+
+  test('GET /api/voicemail/:id/audio securely proxies Twilio audio', async () => {
+    const app = makeApp();
+    const audioBytes = Buffer.from([1, 2, 3, 4]);
+
+    prismaMock.voicemail.findFirst.mockResolvedValueOnce({
+      audioUrl: 'https://api.twilio.com/recording.mp3',
+    });
+
+    fetchTwilioMediaMock.mockResolvedValueOnce({
+      headers: {
+        get: jest.fn((name) => {
+          if (name === 'content-type') return 'audio/mpeg';
+          if (name === 'content-length') {
+            return String(audioBytes.length);
+          }
+          return null;
+        }),
+      },
+      body: null,
+      arrayBuffer: jest.fn().mockResolvedValue(
+        audioBytes.buffer.slice(
+          audioBytes.byteOffset,
+          audioBytes.byteOffset + audioBytes.byteLength,
+        ),
+      ),
+    });
+
+    const res = await request(app)
+      .get('/api/voicemail/vm-audio/audio')
+      .expect(200);
+
+    expect(prismaMock.voicemail.findFirst).toHaveBeenCalledWith({
+      where: {
+        id: 'vm-audio',
+        userId: 123,
+        deleted: false,
+      },
+      select: {
+        audioUrl: true,
+      },
+    });
+
+    expect(fetchTwilioMediaMock).toHaveBeenCalledWith(
+      'https://api.twilio.com/recording.mp3',
+    );
+
+    expect(res.headers['content-type']).toMatch(/^audio\/mpeg/);
+    expect(Buffer.from(res.body)).toEqual(audioBytes);
+  });
+
+  test('GET /api/voicemail/:id/audio rejects another user or missing audio', async () => {
+    const app = makeApp();
+
+    prismaMock.voicemail.findFirst.mockResolvedValueOnce(null);
+
+    const res = await request(app)
+      .get('/api/voicemail/missing/audio')
+      .expect(404);
+
+    expect(res.body).toEqual({
+      error: 'Voicemail audio not found',
+    });
+
+    expect(fetchTwilioMediaMock).not.toHaveBeenCalled();
   });
 
   test('PATCH /api/voicemail/:id/read marks voicemail as read/unread (success)', async () => {

--- a/server/routes/voicemail.js
+++ b/server/routes/voicemail.js
@@ -3,6 +3,7 @@ import prisma from '../utils/prismaClient.js';
 import { requireAuth } from '../middleware/auth.js';
 import { asyncHandler } from '../utils/asyncHandler.js';
 import { emitToUser } from '../services/socketBus.js';
+import { fetchTwilioMedia } from '../utils/twilioMediaProxy.js';
 
 const r = express.Router();
 
@@ -31,6 +32,65 @@ r.get(
     });
 
     res.json({ voicemails });
+  }),
+);
+
+/**
+ * GET /api/voicemail/:id/audio
+ *
+ * Securely proxy a voicemail recording from Twilio.
+ * The Twilio Auth Token remains on the backend.
+ */
+r.get(
+  '/:id/audio',
+  asyncHandler(async (req, res) => {
+    const userId = Number(req.user.id);
+    const { id } = req.params;
+
+    const voicemail = await prisma.voicemail.findFirst({
+      where: {
+        id,
+        userId,
+        deleted: false,
+      },
+      select: {
+        audioUrl: true,
+      },
+    });
+
+    if (!voicemail?.audioUrl) {
+      return res.status(404).json({
+        error: 'Voicemail audio not found',
+      });
+    }
+
+    const upstream = await fetchTwilioMedia(voicemail.audioUrl);
+
+    const contentType =
+      upstream.headers.get('content-type') || 'audio/mpeg';
+
+    const contentLength =
+      upstream.headers.get('content-length');
+
+    res.setHeader('Content-Type', contentType);
+    res.setHeader('Cache-Control', 'private, max-age=60');
+
+    if (contentLength) {
+      res.setHeader('Content-Length', contentLength);
+    }
+
+    if (
+      upstream.body &&
+      typeof upstream.body.pipe === 'function'
+    ) {
+      return upstream.body.pipe(res);
+    }
+
+    const arrayBuffer = await upstream.arrayBuffer();
+
+    return res.status(200).send(
+      Buffer.from(arrayBuffer)
+    );
   }),
 );
 


### PR DESCRIPTION
## Summary

- Add an authenticated voicemail audio endpoint
- Proxy protected Twilio recordings through the backend
- Keep Twilio credentials out of the Android app
- Verify voicemail ownership before returning audio
- Add success and unauthorized/missing-audio tests

## Testing

- Voicemail test suite: 7 passed
- Node syntax checks passed
- git diff --check passed