### PR TITLE
Preserve declined calls from late Twilio callbacks

### DIFF
--- a/server/__tests__/voiceWebhooks.test.js
+++ b/server/__tests__/voiceWebhooks.test.js
@@ -644,6 +644,49 @@ describe('POST /webhooks/voice/app-call-complete', () => {
       expect.anything()
     );
   });
+
+  it('preserves an explicit client decline when Twilio later reports no-answer', async () => {
+    prisma.call.findFirst.mockResolvedValueOnce({
+      id: 777,
+      callerId: 42,
+      calleeId: 99,
+      status: 'DECLINED',
+      endReason: 'declined',
+      endedAt: new Date('2026-07-23T23:18:57.000Z'),
+      startedAt: null,
+    });
+
+    const app = createApp();
+
+    const res = await request(app)
+      .post(
+        '/webhooks/voice/app-call-complete' +
+          '?callerUserId=42' +
+          '&calleeUserId=99' +
+          '&backendCallId=777'
+      )
+      .type('form')
+      .send({
+        DialCallStatus: 'no-answer',
+        DialCallDuration: '0',
+      });
+
+    expect(res.statusCode).toBe(200);
+
+    const actions = JSON.parse(res.text);
+
+    expect(
+      actions.some((action) => action.type === 'hangup')
+    ).toBe(true);
+
+    expect(
+      actions.some((action) => action.type === 'record')
+    ).toBe(false);
+
+    expect(prisma.call.update).not.toHaveBeenCalled();
+    expect(prisma.user.findUnique).not.toHaveBeenCalled();
+    expect(emitToUser).not.toHaveBeenCalled();
+  });
 });
 
 // -----------------------------------------------------------------------------

--- a/server/routes/voiceWebhooks.js
+++ b/server/routes/voiceWebhooks.js
@@ -332,6 +332,9 @@ router.post('/app-call-complete', async (req, res) => {
           id: true,
           callerId: true,
           calleeId: true,
+          status: true,
+          endReason: true,
+          endedAt: true,
           startedAt: true,
         },
       });
@@ -361,12 +364,31 @@ router.post('/app-call-complete', async (req, res) => {
           id: true,
           callerId: true,
           calleeId: true,
+          status: true,
+          endReason: true,
+          endedAt: true,
           startedAt: true,
         },
       });
     }
 
     if (existing) {
+      const existingStatus =
+        String(existing.status || '').toUpperCase();
+
+      // A client may deliberately finalize the call before Twilio's Dial
+      // callback arrives. Do not let a late provider no-answer result
+      // overwrite an explicit decline, hang-up, or failure.
+      if (
+        existingStatus === 'DECLINED' ||
+        existingStatus === 'ENDED' ||
+        existingStatus === 'FAILED' ||
+        existingStatus === 'MISSED'
+      ) {
+        twiml.hangup();
+        return res.type('text/xml').send(twiml.toString());
+      }
+
       let status = 'ENDED';
       let endReason = 'completed';
 


### PR DESCRIPTION
## Summary

- Preserves terminal call statuses when a late Twilio app-call completion callback arrives
- Prevents DECLINED calls from being overwritten as MISSED / no_answer
- Prevents terminal calls from entering voicemail because of a late or repeated callback
- Adds a regression test for an explicit client decline followed by Twilio no-answer

## Testing

Passed focused app-call completion tests:

- Genuine unanswered call becomes MISSED and offers voicemail
- Explicitly declined call remains DECLINED and does not offer voicemail

Command:

NODE_OPTIONS=--experimental-vm-modules npx jest __tests__/voiceWebhooks.test.js --runInBand --coverage=false -t "stops the unanswered recipient|preserves an explicit client decline"

Result:

- 2 passed
- 13 skipped

Note: The full voiceWebhooks test file currently has five unrelated pre-existing expectation failures.