### PR TITLE
fix: preserve first terminal call state

### DIFF
--- a/server/__tests__/calls.routes.test.js
+++ b/server/__tests__/calls.routes.test.js
@@ -13,6 +13,7 @@ const mockPrisma = {
     create: jest.fn(),
     findUnique: jest.fn(),
     update: jest.fn(),
+    updateMany: jest.fn(),
     delete: jest.fn(),
     findMany: jest.fn(),
   },
@@ -80,6 +81,7 @@ describe('calls routes', () => {
     mockPrisma.call.create.mockReset();
     mockPrisma.call.findUnique.mockReset();
     mockPrisma.call.update.mockReset();
+    mockPrisma.call.updateMany.mockReset();
     mockPrisma.call.delete.mockReset();
     mockPrisma.call.findMany.mockReset();
 
@@ -465,23 +467,26 @@ describe('calls routes', () => {
     test('200 on declined, emits call:ended with DECLINED', async () => {
       const now = new Date('2025-01-03T00:00:00.000Z');
 
-      mockPrisma.call.findUnique.mockResolvedValue({
-        id: 1,
-        callerId: 10,
-        calleeId: 20,
-        mode: 'AUDIO',
-        participants: [{ userId: 10 }, { userId: 20 }],
-      });
+      mockPrisma.call.findUnique
+        .mockResolvedValueOnce({
+          id: 1,
+          callerId: 10,
+          calleeId: 20,
+          mode: 'AUDIO',
+          status: 'RINGING',
+          participants: [{ userId: 10 }, { userId: 20 }],
+        })
+        .mockResolvedValueOnce({
+          id: 1,
+          callerId: 10,
+          calleeId: 20,
+          status: 'DECLINED',
+          endedAt: now,
+          durationSec: undefined,
+          endReason: 'declined',
+        });
 
-      mockPrisma.call.update.mockResolvedValue({
-        id: 1,
-        callerId: 10,
-        calleeId: 20,
-        status: 'DECLINED',
-        endedAt: now,
-        durationSec: undefined,
-        endReason: 'declined',
-      });
+      mockPrisma.call.updateMany.mockResolvedValue({ count: 1 });
 
       const res = await request(app)
         .post('/calls/end')
@@ -490,27 +495,16 @@ describe('calls routes', () => {
       expect(res.statusCode).toBe(200);
       expect(res.body).toEqual({ ok: true });
 
-      expect(mockPrisma.call.findUnique).toHaveBeenCalledWith({
-        where: { id: 1 },
-        include: { participants: true },
-      });
-
-      expect(mockPrisma.call.update).toHaveBeenCalledWith({
-        where: { id: 1 },
+      expect(mockPrisma.call.updateMany).toHaveBeenCalledWith({
+        where: {
+          id: 1,
+          status: { notIn: ['ENDED', 'DECLINED', 'MISSED', 'FAILED'] },
+        },
         data: {
           status: 'DECLINED',
           endedAt: expect.any(Date),
           durationSec: undefined,
           endReason: 'declined',
-        },
-        select: {
-          id: true,
-          callerId: true,
-          calleeId: true,
-          status: true,
-          endedAt: true,
-          durationSec: true,
-          endReason: true,
         },
       });
 
@@ -526,50 +520,42 @@ describe('calls routes', () => {
     test('200 on hangup, emits call:ended with ENDED', async () => {
       const now = new Date('2025-01-04T00:00:00.000Z');
 
-      mockPrisma.call.findUnique.mockResolvedValue({
-        id: 1,
-        callerId: 30,
-        calleeId: 10,
-        mode: 'AUDIO',
-        participants: [{ userId: 30 }, { userId: 10 }],
-      });
+      mockPrisma.call.findUnique
+        .mockResolvedValueOnce({
+          id: 1,
+          callerId: 30,
+          calleeId: 10,
+          mode: 'AUDIO',
+          status: 'ACTIVE',
+          participants: [{ userId: 30 }, { userId: 10 }],
+        })
+        .mockResolvedValueOnce({
+          id: 1,
+          callerId: 30,
+          calleeId: 10,
+          status: 'ENDED',
+          endedAt: now,
+          durationSec: undefined,
+          endReason: null,
+        });
 
-      mockPrisma.call.update.mockResolvedValue({
-        id: 1,
-        callerId: 30,
-        calleeId: 10,
-        status: 'ENDED',
-        endedAt: now,
-        durationSec: undefined,
-        endReason: null,
-      });
+      mockPrisma.call.updateMany.mockResolvedValue({ count: 1 });
 
       const res = await request(app).post('/calls/end').send({ callId: 1 });
 
       expect(res.statusCode).toBe(200);
       expect(res.body).toEqual({ ok: true });
 
-      expect(mockPrisma.call.findUnique).toHaveBeenCalledWith({
-        where: { id: 1 },
-        include: { participants: true },
-      });
-
-      expect(mockPrisma.call.update).toHaveBeenCalledWith({
-        where: { id: 1 },
+      expect(mockPrisma.call.updateMany).toHaveBeenCalledWith({
+        where: {
+          id: 1,
+          status: { notIn: ['ENDED', 'DECLINED', 'MISSED', 'FAILED'] },
+        },
         data: {
           status: 'ENDED',
           endedAt: expect.any(Date),
           durationSec: undefined,
           endReason: null,
-        },
-        select: {
-          id: true,
-          callerId: true,
-          calleeId: true,
-          status: true,
-          endedAt: true,
-          durationSec: true,
-          endReason: true,
         },
       });
 
@@ -580,6 +566,96 @@ describe('calls routes', () => {
         durationSec: undefined,
         reason: null,
       });
+    });
+
+    test('does not overwrite or re-emit when another terminal update already won', async () => {
+      mockPrisma.call.findUnique.mockResolvedValue({
+        id: 1,
+        callerId: 10,
+        calleeId: 20,
+        mode: 'VIDEO',
+        status: 'ENDED',
+        participants: [{ userId: 10 }, { userId: 20 }],
+      });
+
+      mockPrisma.call.updateMany.mockResolvedValue({ count: 0 });
+
+      const res = await request(app)
+        .post('/calls/end')
+        .send({
+          callId: 1,
+          reason: 'hangup',
+          durationSec: 999,
+        });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body).toEqual({ ok: true });
+      expect(emitToUserMock).not.toHaveBeenCalled();
+      expect(mockPrisma.call.findUnique).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('PATCH /calls/:id/status', () => {
+    test('a late terminal patch does not overwrite or re-emit the winning terminal state', async () => {
+      const startedAt = new Date('2025-01-05T00:00:00.000Z');
+      const endedAt = new Date('2025-01-05T00:01:00.000Z');
+
+      mockPrisma.call.findUnique
+        .mockResolvedValueOnce({
+          id: 1,
+          callerId: 20,
+          calleeId: 10,
+          mode: 'VIDEO',
+          status: 'ENDED',
+          participants: [{ userId: 20 }, { userId: 10 }],
+        })
+        .mockResolvedValueOnce({
+          id: 1,
+          callerId: 20,
+          calleeId: 10,
+          mode: 'VIDEO',
+          status: 'ENDED',
+          startedAt,
+          endedAt,
+          durationSec: 60,
+          endReason: 'hangup',
+          twilioCallSid: null,
+        });
+
+      mockPrisma.call.updateMany.mockResolvedValue({ count: 0 });
+
+      const res = await request(app)
+        .patch('/calls/1/status')
+        .send({
+          status: 'ENDED',
+          endedAt: '2025-01-05T00:02:00.000Z',
+          durationSec: 120,
+          endReason: 'remote_ended',
+        });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body.call).toMatchObject({
+        id: 1,
+        status: 'ENDED',
+        durationSec: 60,
+        endReason: 'hangup',
+      });
+
+      expect(mockPrisma.call.updateMany).toHaveBeenCalledWith({
+        where: {
+          id: 1,
+          status: { notIn: ['ENDED', 'DECLINED', 'MISSED', 'FAILED'] },
+        },
+        data: {
+          status: 'ENDED',
+          startedAt: undefined,
+          endedAt: new Date('2025-01-05T00:02:00.000Z'),
+          durationSec: 120,
+          endReason: 'remote_ended',
+        },
+      });
+
+      expect(emitToUserMock).not.toHaveBeenCalled();
     });
   });
 });

--- a/server/routes/calls.js
+++ b/server/routes/calls.js
@@ -8,6 +8,17 @@ import { sendPushToUser, sendVoipCallPushToUser } from '../services/pushService.
 const router = express.Router();
 router.use(requireAuth);
 
+const TERMINAL_CALL_STATUSES = [
+  'ENDED',
+  'DECLINED',
+  'MISSED',
+  'FAILED',
+];
+
+function isTerminalCallStatus(status) {
+  return TERMINAL_CALL_STATUSES.includes(String(status || '').toUpperCase());
+}
+
 async function ensureParticipant(call, userId) {
   if (!call) return false;
 
@@ -398,14 +409,28 @@ router.post('/end', asyncHandler(async (req, res) => {
 
   const endedAt = new Date();
 
-  const updated = await prisma.call.update({
-    where: { id: call.id },
+  const finalization = await prisma.call.updateMany({
+    where: {
+      id: call.id,
+      status: { notIn: TERMINAL_CALL_STATUSES },
+    },
     data: {
       status,
       endedAt,
       durationSec: durationSec ?? undefined,
       endReason: reason ?? null,
     },
+  });
+
+  // A different client or reconciliation request already finalized the call.
+  // Treat this retry as successful, but do not overwrite terminal fields or
+  // emit duplicate call-ended events.
+  if (finalization.count === 0) {
+    return res.json({ ok: true });
+  }
+
+  const updated = await prisma.call.findUnique({
+    where: { id: call.id },
     select: {
       id: true,
       callerId: true,
@@ -448,6 +473,13 @@ router.post('/end', asyncHandler(async (req, res) => {
     }
   }
 
+  console.log('[calls/end] finalized call', {
+    callId: updated.id,
+    status: updated.status,
+    endedBy: userId,
+    notified: Array.from(notifyIds),
+  });
+
   res.json({ ok: true });
 }));
 
@@ -479,8 +511,11 @@ router.patch('/:id/status', asyncHandler(async (req, res) => {
     return res.status(403).json({ error: 'Not a participant' });
   }
 
+  const normalizedStatus =
+    status == null ? null : String(status).toUpperCase();
+
   const updateData = {
-    status: status ?? undefined,
+    status: normalizedStatus ?? undefined,
     startedAt: startedAt ? new Date(startedAt) : undefined,
     endedAt: endedAt ? new Date(endedAt) : undefined,
     durationSec: durationSec ?? undefined,
@@ -504,9 +539,16 @@ router.patch('/:id/status', asyncHandler(async (req, res) => {
     }
   }
 
-  const updated = await prisma.call.update({
-    where: { id: callId },
+  const lifecycleUpdate = await prisma.call.updateMany({
+    where: {
+      id: callId,
+      status: { notIn: TERMINAL_CALL_STATUSES },
+    },
     data: updateData,
+  });
+
+  const updated = await prisma.call.findUnique({
+    where: { id: callId },
     select: {
       id: true,
       callerId: true,
@@ -521,16 +563,7 @@ router.patch('/:id/status', asyncHandler(async (req, res) => {
     },
   });
 
-  const terminalStatuses = new Set([
-    'ENDED',
-    'DECLINED',
-    'MISSED',
-    'FAILED',
-  ]);
-
-  const updatedStatus = String(updated.status || '').toUpperCase();
-
-  if (terminalStatuses.has(updatedStatus)) {
+  if (lifecycleUpdate.count === 1 && isTerminalCallStatus(normalizedStatus)) {
     const notifyIds = new Set();
 
     if (updated.callerId && updated.callerId !== userId) {


### PR DESCRIPTION
## Summary

- make terminal call updates atomic
- preserve the first successful terminal status, timestamp, duration, and reason
- prevent later client reconciliation requests from overwriting finalized calls
- prevent duplicate call-ended and video-ended events
- log which client successfully finalized the call
- add regression coverage for duplicate terminal requests

## Validation

- call route syntax check passed
- targeted call route test suite passed: 19/19 tests
- `git diff --check` passed

## Broader test-suite status

The full server suite was also run:

- 193 test suites passed
- 14 test suites failed
- 1,255 tests passed
- 24 tests failed

The broader failures were not investigated or addressed as part of this focused call-lifecycle change.