### PR TITLE
Improve backend call reliability, Ria memory, and invite delivery

### DIFF
--- a/server/__tests__/calls.routes.test.js
+++ b/server/__tests__/calls.routes.test.js
@@ -6,11 +6,14 @@ import express from 'express';
 import request from 'supertest';
 
 const mockPrisma = {
+  $transaction: jest.fn(),
+  $executeRaw: jest.fn(),
   user: {
     findUnique: jest.fn(),
   },
   call: {
     create: jest.fn(),
+    findFirst: jest.fn(),
     findUnique: jest.fn(),
     update: jest.fn(),
     updateMany: jest.fn(),
@@ -76,12 +79,29 @@ describe('calls routes', () => {
 
     jest.clearAllMocks();
 
+    mockPrisma.$transaction
+      .mockReset()
+      .mockImplementation(async (callback) =>
+        callback(mockPrisma)
+      );
+
+    mockPrisma.$executeRaw
+      .mockReset()
+      .mockResolvedValue(undefined);
+
     mockPrisma.user.findUnique.mockReset();
 
     mockPrisma.call.create.mockReset();
+    mockPrisma.call.findFirst
+      .mockReset()
+      .mockResolvedValue(null);
     mockPrisma.call.findUnique.mockReset();
     mockPrisma.call.update.mockReset();
-    mockPrisma.call.updateMany.mockReset();
+    mockPrisma.call.updateMany
+      .mockReset()
+      .mockResolvedValue({
+        count: 0,
+      });
     mockPrisma.call.delete.mockReset();
     mockPrisma.call.findMany.mockReset();
 

--- a/server/__tests__/peopleInvites.test.js
+++ b/server/__tests__/peopleInvites.test.js
@@ -5,6 +5,8 @@ import { jest } from '@jest/globals';
 const mockFindUnique = jest.fn();
 const mockCreate = jest.fn();
 const mockUpdate = jest.fn();
+const mockUserFindUnique = jest.fn();
+const mockSendSms = jest.fn();
 
 await jest.unstable_mockModule('../utils/prismaClient.js', () => ({
   __esModule: true,
@@ -14,15 +16,26 @@ await jest.unstable_mockModule('../utils/prismaClient.js', () => ({
       create: mockCreate,
       update: mockUpdate,
     },
+    user: {
+      findUnique: mockUserFindUnique,
+    },
   },
 }));
 
 await jest.unstable_mockModule('../middleware/auth.js', () => ({
   __esModule: true,
   requireAuth: (req, _res, next) => {
-    req.user = { id: 'user-123' };
+    req.user = {
+      id: 'user-123',
+      username: 'testuser',
+    };
     next();
   },
+}));
+
+await jest.unstable_mockModule('../lib/telco/index.js', () => ({
+  __esModule: true,
+  sendSms: mockSendSms,
 }));
 
 const { default: router } = await import('../routes/peopleInvites.js');
@@ -41,6 +54,23 @@ describe('peopleInvites routes', () => {
   beforeEach(() => {
     app = makeApp();
     jest.clearAllMocks();
+
+    mockUserFindUnique.mockResolvedValue({
+      username: 'testuser',
+      phoneNumber: '+13035550000',
+    });
+
+    mockSendSms.mockResolvedValue({
+      ok: true,
+      provider: 'twilio',
+      messageSid: 'SM_TEST_INVITE',
+    });
+
+    mockUpdate.mockResolvedValue({
+      id: 'invite-1',
+      status: 'revoked',
+    });
+
     process.env = {
       ...OLD_ENV,
       APP_BASE_URL: 'https://chatforia.com',
@@ -85,6 +115,23 @@ describe('peopleInvites routes', () => {
           channel: 'sms',
         },
       });
+
+      expect(mockSendSms).toHaveBeenCalledTimes(1);
+      expect(mockSendSms).toHaveBeenCalledWith({
+        to: '+17195551234',
+        text: expect.stringContaining(
+          'https://chatforia.com/i/abc123xyz0'
+        ),
+        clientRef: expect.stringMatching(
+          /^people-invite:invite-1:/
+        ),
+      });
+
+      expect(
+        mockSendSms.mock.calls[0][0].text
+      ).toContain(
+        'testuser invited you to Chatforia'
+      );
     });
 
     it('defaults channel to share_link when blank', async () => {
@@ -114,6 +161,110 @@ describe('peopleInvites routes', () => {
           targetEmail: null,
           channel: 'share_link',
         }),
+      });
+    });
+
+    it('does not call Twilio for a share-link invite', async () => {
+      mockFindUnique.mockResolvedValueOnce(null);
+
+      mockCreate.mockResolvedValueOnce({
+        id: 'invite-share-1',
+        code: 'sharecode1',
+        inviterUserId: 'user-123',
+        targetPhone: null,
+        targetEmail: null,
+        channel: 'share_link',
+      });
+
+      const res = await request(app)
+        .post('/people-invites')
+        .send({
+          channel: 'share_link',
+        });
+
+      expect(res.status).toBe(201);
+      expect(res.body.url).toBe(
+        'https://chatforia.com/i/sharecode1'
+      );
+      expect(mockSendSms).not.toHaveBeenCalled();
+      expect(mockUserFindUnique).not.toHaveBeenCalled();
+    });
+
+    it('requires a phone number for an SMS invite', async () => {
+      const res = await request(app)
+        .post('/people-invites')
+        .send({
+          channel: 'sms',
+        });
+
+      expect(res.status).toBe(400);
+      expect(res.body).toEqual({
+        error: 'A phone number is required for SMS invites.',
+      });
+
+      expect(mockCreate).not.toHaveBeenCalled();
+      expect(mockSendSms).not.toHaveBeenCalled();
+    });
+
+    it('rejects an SMS invite to the inviter own phone number', async () => {
+      mockUserFindUnique.mockResolvedValueOnce({
+        username: 'testuser',
+        phoneNumber: '+17195551234',
+      });
+
+      const res = await request(app)
+        .post('/people-invites')
+        .send({
+          targetPhone: '(719) 555-1234',
+          channel: 'sms',
+        });
+
+      expect(res.status).toBe(400);
+      expect(res.body).toEqual({
+        error: 'You cannot invite your own phone number.',
+      });
+
+      expect(mockCreate).not.toHaveBeenCalled();
+      expect(mockSendSms).not.toHaveBeenCalled();
+    });
+
+    it('revokes the invite and returns 502 when Twilio fails', async () => {
+      mockFindUnique.mockResolvedValueOnce(null);
+
+      mockCreate.mockResolvedValueOnce({
+        id: 'invite-failed-1',
+        code: 'failedsms1',
+        inviterUserId: 'user-123',
+        targetPhone: '+17195551234',
+        targetEmail: null,
+        channel: 'sms',
+        status: 'pending',
+      });
+
+      mockSendSms.mockRejectedValueOnce(
+        new Error('Twilio unavailable')
+      );
+
+      const res = await request(app)
+        .post('/people-invites')
+        .send({
+          targetPhone: '(719) 555-1234',
+          channel: 'sms',
+        });
+
+      expect(res.status).toBe(502);
+      expect(res.body).toEqual({
+        error: 'Failed to send invite SMS.',
+      });
+
+      expect(mockSendSms).toHaveBeenCalledTimes(1);
+      expect(mockUpdate).toHaveBeenCalledWith({
+        where: {
+          id: 'invite-failed-1',
+        },
+        data: {
+          status: 'revoked',
+        },
       });
     });
 

--- a/server/__tests__/telco.driver.test.js
+++ b/server/__tests__/telco.driver.test.js
@@ -41,6 +41,7 @@ describe('telco driver (Twilio only)', () => {
     });
 
     expect(res).toEqual({
+      ok: true,
       provider: 'twilio',
       messageSid: 'SM_mock_123',
     });
@@ -65,6 +66,7 @@ describe('telco driver (Twilio only)', () => {
     });
 
     expect(res).toEqual({
+      ok: true,
       provider: 'twilio',
       messageSid: 'SM_mock_123',
     });

--- a/server/__tests__/voiceClient.test.js
+++ b/server/__tests__/voiceClient.test.js
@@ -26,7 +26,7 @@ await jest.unstable_mockModule('twilio', () => {
       this.apiKeySid = apiKeySid;
       this.apiKeySecret = apiKeySecret;
       this.opts = opts;
-      this.identity = null;
+      this.identity = opts?.identity ?? null;
       this.grants = [];
     }
 
@@ -130,8 +130,8 @@ describe('POST /voice/token', () => {
 
     expect(res.status).toBe(200);
     expect(res.body).toEqual({
-      token: 'mock-jwt-for-user:42',
-      identity: 'user:42',
+      token: 'mock-jwt-for-user_42',
+      identity: 'user_42',
       ttlSeconds: 60 * 60,
     });
   });

--- a/server/__tests__/voiceWebhooks.test.js
+++ b/server/__tests__/voiceWebhooks.test.js
@@ -51,8 +51,18 @@ class MockVoiceResponse {
         dial.numbers.push({ to });
         return this;
       },
-      client: (to) => {
-        dial.clients.push({ to });
+      client: (optionsOrIdentity, maybeIdentity) => {
+        if (maybeIdentity === undefined) {
+          dial.clients.push({
+            to: optionsOrIdentity,
+          });
+        } else {
+          dial.clients.push({
+            to: maybeIdentity,
+            opts: optionsOrIdentity || {},
+          });
+        }
+
         return this;
       },
     };
@@ -483,6 +493,12 @@ describe('POST /webhooks/voice/client app-to-app voicemail handoff', () => {
     expect(actions[0].clients).toEqual([
       {
         to: 'user_99',
+        opts: {
+          statusCallback:
+            '/webhooks/voice/app-call-progress?backendCallId=777',
+          statusCallbackEvent: 'answered',
+          statusCallbackMethod: 'POST',
+        },
       },
     ]);
 
@@ -608,7 +624,7 @@ describe('POST /webhooks/voice/app-call-complete', () => {
   });
 
   it.each(['busy', 'no-answer'])(
-    'continues an explicit client decline into voicemail when Twilio reports %s',
+    'hangs up without voicemail after an explicit client decline when Twilio reports %s',
     async (dialCallStatus) => {
       prisma.call.findFirst.mockResolvedValueOnce({
         id: 777,
@@ -619,24 +635,6 @@ describe('POST /webhooks/voice/app-call-complete', () => {
         endedAt: new Date('2026-07-23T23:18:57.000Z'),
         startedAt: null,
       });
-
-      prisma.user.findUnique
-        .mockResolvedValueOnce({
-          id: 99,
-          voicemailEnabled: true,
-          voicemailGreetingUrl: null,
-          voicemailGreetingText: 'Please leave Julian a message.',
-          assignedNumbers: [
-            {
-              id: 12,
-              e164: '+15550009999',
-            },
-          ],
-        })
-        .mockResolvedValueOnce({
-          id: 42,
-          assignedNumbers: [],
-        });
 
       const app = createApp();
 
@@ -656,27 +654,24 @@ describe('POST /webhooks/voice/app-call-complete', () => {
       expect(res.statusCode).toBe(200);
 
       const actions = JSON.parse(res.text);
-      const recordAction = actions.find(
-        (action) => action.type === 'record'
-      );
 
-      expect(recordAction).toBeDefined();
-
-      const completionUrl = new URL(
-        recordAction.opts.action,
-        'https://chatforia.test'
-      );
+      expect(actions).toEqual([
+        {
+          type: 'hangup',
+        },
+      ]);
 
       expect(
-        completionUrl.searchParams.get('relatedCallId')
-      ).toBe('777');
+        actions.some((action) => action.type === 'record')
+      ).toBe(false);
 
+      expect(prisma.user.findUnique).not.toHaveBeenCalled();
       expect(prisma.call.update).not.toHaveBeenCalled();
       expect(emitToUser).not.toHaveBeenCalled();
     }
   );
 
-  it('records a Twilio busy result as declined and sends the caller into voicemail', async () => {
+  it('records a Twilio busy result as declined without offering voicemail', async () => {
     prisma.call.findFirst.mockResolvedValueOnce({
       id: 777,
       callerId: 42,
@@ -694,26 +689,8 @@ describe('POST /webhooks/voice/app-call-complete', () => {
       status: 'DECLINED',
       endedAt: new Date('2026-07-24T02:00:00.000Z'),
       durationSec: 0,
-      endReason: 'declined_to_voicemail',
+      endReason: 'declined',
     });
-
-    prisma.user.findUnique
-      .mockResolvedValueOnce({
-        id: 99,
-        voicemailEnabled: true,
-        voicemailGreetingUrl: null,
-        voicemailGreetingText: 'Please leave Julian a message.',
-        assignedNumbers: [
-          {
-            id: 12,
-            e164: '+15550009999',
-          },
-        ],
-      })
-      .mockResolvedValueOnce({
-        id: 42,
-        assignedNumbers: [],
-      });
 
     const app = createApp();
 
@@ -734,19 +711,27 @@ describe('POST /webhooks/voice/app-call-complete', () => {
 
     const actions = JSON.parse(res.text);
 
+    expect(actions).toEqual([
+      {
+        type: 'hangup',
+      },
+    ]);
+
     expect(
       actions.some((action) => action.type === 'record')
-    ).toBe(true);
+    ).toBe(false);
 
     expect(prisma.call.update).toHaveBeenCalledWith(
       expect.objectContaining({
         where: { id: 777 },
         data: expect.objectContaining({
           status: 'DECLINED',
-          endReason: 'declined_to_voicemail',
+          endReason: 'declined',
         }),
       })
     );
+
+    expect(prisma.user.findUnique).not.toHaveBeenCalled();
 
     expect(emitToUser).toHaveBeenCalledWith(
       99,
@@ -754,7 +739,7 @@ describe('POST /webhooks/voice/app-call-complete', () => {
       expect.objectContaining({
         callId: 777,
         status: 'DECLINED',
-        reason: 'declined_to_voicemail',
+        reason: 'declined',
       })
     );
   });
@@ -954,7 +939,7 @@ describe('POST /webhooks/voice/app-call-complete older client fallback', () => {
     expect(completionUrl.searchParams.get('relatedCallId')).toBe('888');
   });
 
-  it('continues a declined fallback call into voicemail', async () => {
+  it('hangs up a declined fallback call without offering voicemail', async () => {
     prisma.call.findFirst.mockResolvedValueOnce({
       id: 888,
       callerId: 42,
@@ -964,24 +949,6 @@ describe('POST /webhooks/voice/app-call-complete older client fallback', () => {
       endedAt: new Date('2026-07-24T01:01:39.000Z'),
       startedAt: null,
     });
-
-    prisma.user.findUnique
-      .mockResolvedValueOnce({
-        id: 99,
-        voicemailEnabled: true,
-        voicemailGreetingUrl: null,
-        voicemailGreetingText: 'Please leave a message.',
-        assignedNumbers: [
-          {
-            id: 12,
-            e164: '+15550009999',
-          },
-        ],
-      })
-      .mockResolvedValueOnce({
-        id: 42,
-        assignedNumbers: [],
-      });
 
     const app = createApp();
 
@@ -1000,19 +967,18 @@ describe('POST /webhooks/voice/app-call-complete older client fallback', () => {
     expect(res.statusCode).toBe(200);
 
     const actions = JSON.parse(res.text);
-    const recordAction = actions.find(
-      (action) => action.type === 'record'
-    );
 
-    expect(recordAction).toBeDefined();
+    expect(actions).toEqual([
+      {
+        type: 'hangup',
+      },
+    ]);
 
-    const completionUrl = new URL(
-      recordAction.opts.action,
-      'https://chatforia.test'
-    );
+    expect(
+      actions.some((action) => action.type === 'record')
+    ).toBe(false);
 
-    expect(completionUrl.searchParams.get('relatedCallId')).toBe('888');
-
+    expect(prisma.user.findUnique).not.toHaveBeenCalled();
     expect(prisma.call.update).not.toHaveBeenCalled();
     expect(emitToUser).not.toHaveBeenCalled();
   });

--- a/server/prisma/migrations/20260731021328_rename_foria_message_to_ria_message/migration.sql
+++ b/server/prisma/migrations/20260731021328_rename_foria_message_to_ria_message/migration.sql
@@ -1,0 +1,12 @@
+ALTER TABLE "ForiaMessage"
+RENAME TO "RiaMessage";
+
+ALTER INDEX "ForiaMessage_pkey"
+RENAME TO "RiaMessage_pkey";
+
+ALTER INDEX "ForiaMessage_userId_createdAt_idx"
+RENAME TO "RiaMessage_userId_createdAt_idx";
+
+ALTER TABLE "RiaMessage"
+RENAME CONSTRAINT "ForiaMessage_userId_fkey"
+TO "RiaMessage_userId_fkey";

--- a/server/routes/calls.js
+++ b/server/routes/calls.js
@@ -73,13 +73,28 @@ router.post('/invite', asyncHandler(async (req, res) => {
     return res.status(400).json({ error: 'Invalid mode' });
   }
 
+  const targetCalleeId = Number(calleeId);
+
+  if (
+    !Number.isInteger(targetCalleeId) ||
+    targetCalleeId <= 0
+  ) {
+    return res.status(400).json({ error: 'Invalid calleeId' });
+  }
+
+  if (targetCalleeId === callerId) {
+    return res.status(400).json({
+      error: 'Cannot call yourself',
+    });
+  }
+
   const [caller, callee] = await Promise.all([
     prisma.user.findUnique({
       where: { id: callerId },
       select: { id: true, username: true, displayName: true, avatarUrl: true },
     }),
     prisma.user.findUnique({
-      where: { id: Number(calleeId) },
+      where: { id: targetCalleeId },
       select: { id: true, username: true, displayName: true, avatarUrl: true },
     }),
   ]);
@@ -88,41 +103,170 @@ router.post('/invite', asyncHandler(async (req, res) => {
     return res.status(404).json({ error: 'Callee not found' });
   }
 
-  const call = await prisma.call.create({
-    data: {
-      callerId,
-      calleeId: Number(calleeId),
-      roomId: roomId ?? null,
-      mode,
-      status: 'RINGING',
-      offerSdp: offer?.sdp ?? null,
-      twilioCallSid: twilioCallSid ?? null,
-      participants: {
-        create: [
-          {
-            userId: callerId,
-            role: 'HOST',
-            status: 'JOINED',
-            joinedAt: new Date(),
-          },
-          {
-            userId: Number(calleeId),
-            role: 'MEMBER',
-            status: 'RINGING',
-          },
-        ],
+  /*
+   * Prevent simultaneous reciprocal calls from creating two live
+   * database records and two Twilio legs.
+   *
+   * Both A -> B and B -> A use the same sorted advisory-lock key.
+   * PostgreSQL releases the lock automatically when this transaction
+   * commits or rolls back.
+   */
+  const lowUserId = Math.min(callerId, targetCalleeId);
+  const highUserId = Math.max(callerId, targetCalleeId);
+
+  const arbitration = await prisma.$transaction(async (tx) => {
+    await tx.$executeRaw`
+      SELECT pg_advisory_xact_lock(
+        CAST(${lowUserId} AS integer),
+        CAST(${highUserId} AS integer)
+      )
+    `;
+
+    const pairWhere = {
+      OR: [
+        {
+          callerId,
+          calleeId: targetCalleeId,
+        },
+        {
+          callerId: targetCalleeId,
+          calleeId: callerId,
+        },
+      ],
+    };
+
+    /*
+     * A pre-answer call should never remain live indefinitely.
+     * Finalize abandoned INITIATED/RINGING rows before checking
+     * whether this user pair already has a current call.
+     */
+    const staleBefore = new Date(Date.now() - 2 * 60 * 1000);
+
+    const staleCleanup = await tx.call.updateMany({
+      where: {
+        ...pairWhere,
+        status: {
+          in: ['INITIATED', 'RINGING'],
+        },
+        createdAt: {
+          lt: staleBefore,
+        },
       },
-    },
-    select: {
-      id: true,
-      callerId: true,
-      calleeId: true,
-      mode: true,
-      status: true,
-      roomId: true,
-      createdAt: true,
-    },
+      data: {
+        status: 'FAILED',
+        endedAt: new Date(),
+        endReason: 'stale_ringing_timeout',
+      },
+    });
+
+    if (staleCleanup.count > 0) {
+      console.info(
+        '[calls/invite] finalized stale pre-answer calls',
+        {
+          callerId,
+          calleeId: targetCalleeId,
+          count: staleCleanup.count,
+        }
+      );
+    }
+
+    const existingCall = await tx.call.findFirst({
+      where: {
+        ...pairWhere,
+        status: {
+          in: ['INITIATED', 'RINGING', 'ACTIVE'],
+        },
+      },
+      orderBy: {
+        id: 'asc',
+      },
+      select: {
+        id: true,
+        callerId: true,
+        calleeId: true,
+        mode: true,
+        status: true,
+        roomId: true,
+        createdAt: true,
+      },
+    });
+
+    if (existingCall) {
+      return {
+        created: false,
+        call: existingCall,
+      };
+    }
+
+    const createdCall = await tx.call.create({
+      data: {
+        callerId,
+        calleeId: targetCalleeId,
+        roomId: roomId ?? null,
+        mode,
+        status: 'RINGING',
+        offerSdp: offer?.sdp ?? null,
+        twilioCallSid: twilioCallSid ?? null,
+        participants: {
+          create: [
+            {
+              userId: callerId,
+              role: 'HOST',
+              status: 'JOINED',
+              joinedAt: new Date(),
+            },
+            {
+              userId: targetCalleeId,
+              role: 'MEMBER',
+              status: 'RINGING',
+            },
+          ],
+        },
+      },
+      select: {
+        id: true,
+        callerId: true,
+        calleeId: true,
+        mode: true,
+        status: true,
+        roomId: true,
+        createdAt: true,
+      },
+    });
+
+    return {
+      created: true,
+      call: createdCall,
+    };
   });
+
+  if (!arbitration.created) {
+    const existingCall = arbitration.call;
+
+    console.info(
+      '[calls/invite] live call already exists for user pair',
+      {
+        requestedCallerId: callerId,
+        requestedCalleeId: targetCalleeId,
+        survivingCallId: existingCall.id,
+        survivingCallerId: existingCall.callerId,
+        survivingCalleeId: existingCall.calleeId,
+        status: existingCall.status,
+      }
+    );
+
+    return res.status(409).json({
+      error: 'CALL_ALREADY_IN_PROGRESS',
+      callId: existingCall.id,
+      resolvedCallId: existingCall.id,
+      callerId: existingCall.callerId,
+      calleeId: existingCall.calleeId,
+      mode: existingCall.mode,
+      status: existingCall.status,
+    });
+  }
+
+  const call = arbitration.call;
 
   const roomName = `call_${call.id}`;
 
@@ -161,6 +305,7 @@ if (mode === 'VIDEO') {
 
   try {
     await sendPushToUser(callee.id, {
+      skipApns: true,
       alert: {
         title: 'Incoming video call',
         body: `${callerName} is calling`,
@@ -206,6 +351,7 @@ if (mode === 'VIDEO') {
 
     try {
       await sendPushToUser(callee.id, {
+        skipApns: true,
         alert: {
           title: 'Incoming call',
           body: `${callerName} is calling`,
@@ -473,6 +619,29 @@ router.post('/end', asyncHandler(async (req, res) => {
     }
   }
 
+  for (const id of notifyIds) {
+    try {
+      await sendPushToUser(id, {
+        data: {
+          type: 'call_ended',
+          callId: updated.id,
+          mode: call.mode,
+          status: updated.status,
+          reason: updated.endReason ?? '',
+        },
+      });
+    } catch (err) {
+      console.warn(
+        '[calls] failed to send terminal call push after /calls/end',
+        {
+          callId: updated.id,
+          userId: id,
+          error: err?.message || err,
+        }
+      );
+    }
+  }
+
   console.log('[calls/end] finalized call', {
     callId: updated.id,
     status: updated.status,
@@ -481,6 +650,43 @@ router.post('/end', asyncHandler(async (req, res) => {
   });
 
   res.json({ ok: true });
+}));
+
+/**
+ * GET /calls/:id/status
+ * Lightweight lifecycle lookup used to reject stale incoming-call pushes.
+ */
+router.get('/:id/status', asyncHandler(async (req, res) => {
+  const userId = Number(req.user.id);
+  const callId = Number(req.params.id);
+
+  if (!Number.isFinite(callId) || callId <= 0) {
+    return res.status(400).json({ error: 'Invalid call id' });
+  }
+
+  const call = await prisma.call.findUnique({
+    where: { id: callId },
+    include: { participants: true },
+  });
+
+  if (!call) {
+    return res.status(404).json({ error: 'Call not found' });
+  }
+
+  if (!(await ensureParticipant(call, userId))) {
+    return res.status(403).json({ error: 'Not a participant' });
+  }
+
+  return res.json({
+    call: {
+      id: call.id,
+      mode: call.mode,
+      status: call.status,
+      endReason: call.endReason,
+      startedAt: call.startedAt,
+      endedAt: call.endedAt,
+    },
+  });
 }));
 
 /**
@@ -516,7 +722,12 @@ router.patch('/:id/status', asyncHandler(async (req, res) => {
 
   const updateData = {
     status: normalizedStatus ?? undefined,
-    startedAt: startedAt ? new Date(startedAt) : undefined,
+    startedAt:
+      startedAt
+        ? new Date(startedAt)
+        : normalizedStatus === 'ACTIVE'
+          ? new Date()
+          : undefined,
     endedAt: endedAt ? new Date(endedAt) : undefined,
     durationSec: durationSec ?? undefined,
     endReason: endReason ?? undefined,
@@ -599,6 +810,29 @@ router.patch('/:id/status', asyncHandler(async (req, res) => {
           durationSec: updated.durationSec,
           reason: updated.endReason,
         });
+      }
+    }
+
+    for (const id of notifyIds) {
+      try {
+        await sendPushToUser(id, {
+          data: {
+            type: 'call_ended',
+            callId: updated.id,
+            mode: updated.mode,
+            status: updated.status,
+            reason: updated.endReason ?? '',
+          },
+        });
+      } catch (err) {
+        console.warn(
+          '[calls] failed to send terminal call push after status patch',
+          {
+            callId: updated.id,
+            userId: id,
+            error: err?.message || err,
+          }
+        );
       }
     }
 

--- a/server/routes/peopleInvites.js
+++ b/server/routes/peopleInvites.js
@@ -2,6 +2,11 @@ import express from 'express';
 import crypto from 'crypto';
 import prisma from '../utils/prismaClient.js';
 import { requireAuth } from '../middleware/auth.js';
+import { sendSms } from '../lib/telco/index.js';
+import {
+  limiterInvites,
+  invitesSmsLimiter,
+} from '../middleware/rateLimits.js';
 
 const router = express.Router();
 
@@ -10,7 +15,12 @@ function makeInviteCode(length = 10) {
 }
 
 function buildInviteUrl(code) {
-  return `${process.env.APP_BASE_URL || "www.chatforia.com"}/i/${code}`;
+  const base = (
+    process.env.APP_BASE_URL ||
+    'https://www.chatforia.com'
+  ).replace(/\/+$/, '');
+
+  return `${base}/i/${encodeURIComponent(code)}`;
 }
 
 function normalizePhone(input) {
@@ -28,52 +38,251 @@ function normalizePhone(input) {
   return `+${digits}`;
 }
 
-// POST /people-invites
-router.post("/", requireAuth, async (req, res) => {
-  try {
-    const inviterUserId = req.user.id;
-    const targetPhone = normalizePhone(req.body?.targetPhone);
-    const targetEmail = typeof req.body?.targetEmail === "string"
-      ? req.body.targetEmail.trim().toLowerCase()
-      : null;
-    const channel = typeof req.body?.channel === "string" && req.body.channel.trim()
-      ? req.body.channel.trim()
-      : "share_link";
+const ALLOWED_CHANNELS = new Set([
+  'share_link',
+  'sms',
+  'email',
+]);
 
-    let code;
-    for (let i = 0; i < 5; i++) {
-      const candidate = makeInviteCode();
-      const exists = await prisma.peopleInvite.findUnique({ where: { code: candidate } });
-      if (!exists) {
-        code = candidate;
-        break;
-      }
-    }
+function normalizeChannel(input) {
+  const channel =
+    typeof input === 'string'
+      ? input.trim().toLowerCase()
+      : '';
 
-    if (!code) {
-      return res.status(500).json({ error: "Failed to generate invite code." });
-    }
+  if (!channel) return 'share_link';
 
-    const invite = await prisma.peopleInvite.create({
-      data: {
-        code,
-        inviterUserId,
-        targetPhone,
-        targetEmail,
-        channel,
-      },
-    });
+  return ALLOWED_CHANNELS.has(channel)
+    ? channel
+    : null;
+}
 
-    return res.status(201).json({
-      ok: true,
-      invite,
-      url: buildInviteUrl(invite.code),
-    });
-  } catch (error) {
-    console.error("people invite create failed", error);
-    return res.status(500).json({ error: "Failed to create invite." });
+function normalizeEmail(input) {
+  if (typeof input !== 'string') return null;
+
+  const email = input.trim().toLowerCase();
+  if (!email) return null;
+
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)
+    ? email
+    : null;
+}
+
+function limitSmsInvitesOnly(req, res, next) {
+  const channel = normalizeChannel(req.body?.channel);
+
+  if (channel !== 'sms') {
+    return next();
   }
-});
+
+  return invitesSmsLimiter(req, res, next);
+}
+
+// POST /people-invites
+router.post(
+  '/',
+  requireAuth,
+  limiterInvites,
+  limitSmsInvitesOnly,
+  async (req, res) => {
+    try {
+      const inviterUserId = req.user.id;
+
+      const rawTargetPhone =
+        typeof req.body?.targetPhone === 'string'
+          ? req.body.targetPhone.trim()
+          : '';
+
+      const rawTargetEmail =
+        typeof req.body?.targetEmail === 'string'
+          ? req.body.targetEmail.trim()
+          : '';
+
+      const targetPhone =
+        normalizePhone(rawTargetPhone);
+
+      const targetEmail =
+        normalizeEmail(rawTargetEmail);
+
+      const channel =
+        normalizeChannel(req.body?.channel);
+
+      if (!channel) {
+        return res.status(400).json({
+          error: 'Invalid invite channel.',
+        });
+      }
+
+      if (rawTargetPhone && !targetPhone) {
+        return res.status(400).json({
+          error: 'Invalid phone number.',
+        });
+      }
+
+      if (rawTargetEmail && !targetEmail) {
+        return res.status(400).json({
+          error: 'Invalid email address.',
+        });
+      }
+
+      if (channel === 'sms' && !targetPhone) {
+        return res.status(400).json({
+          error:
+            'A phone number is required for SMS invites.',
+        });
+      }
+
+      if (channel === 'email' && !targetEmail) {
+        return res.status(400).json({
+          error:
+            'An email address is required for email invites.',
+        });
+      }
+
+      let inviterRecord = null;
+
+      if (channel === 'sms') {
+        inviterRecord =
+          await prisma.user.findUnique({
+            where: {
+              id: inviterUserId,
+            },
+            select: {
+              username: true,
+              phoneNumber: true,
+            },
+          });
+
+        const inviterPhone = normalizePhone(
+          inviterRecord?.phoneNumber
+        );
+
+        if (
+          inviterPhone &&
+          inviterPhone === targetPhone
+        ) {
+          return res.status(400).json({
+            error:
+              'You cannot invite your own phone number.',
+          });
+        }
+      }
+
+      let code;
+
+      for (
+        let attempt = 0;
+        attempt < 5;
+        attempt += 1
+      ) {
+        const candidate = makeInviteCode();
+
+        const exists =
+          await prisma.peopleInvite.findUnique({
+            where: {
+              code: candidate,
+            },
+          });
+
+        if (!exists) {
+          code = candidate;
+          break;
+        }
+      }
+
+      if (!code) {
+        return res.status(500).json({
+          error:
+            'Failed to generate invite code.',
+        });
+      }
+
+      const invite =
+        await prisma.peopleInvite.create({
+          data: {
+            code,
+            inviterUserId,
+            targetPhone,
+            targetEmail,
+            channel,
+          },
+        });
+
+      const inviteUrl =
+        buildInviteUrl(invite.code);
+
+      if (channel === 'sms') {
+        const inviterName =
+          inviterRecord?.username?.trim() ||
+          req.user?.username?.trim() ||
+          'A friend';
+
+        const smsText =
+          `${inviterName} invited you to Chatforia — ` +
+          `a better way to message globally.\n` +
+          `Join here: ${inviteUrl}`;
+
+        const clientRef =
+          `people-invite:${invite.id}:${Date.now()}`;
+
+        try {
+          const sendResult = await sendSms({
+            to: targetPhone,
+            text: smsText,
+            clientRef,
+          });
+
+          if (!sendResult?.messageSid) {
+            throw new Error(
+              'SMS provider did not return a message SID.'
+            );
+          }
+        } catch (smsError) {
+          console.error(
+            'people invite SMS send failed',
+            {
+              inviteId: invite.id,
+              error:
+                smsError?.message ||
+                String(smsError),
+            }
+          );
+
+          await prisma.peopleInvite
+            .update({
+              where: {
+                id: invite.id,
+              },
+              data: {
+                status: 'revoked',
+              },
+            })
+            .catch(() => {});
+
+          return res.status(502).json({
+            error:
+              'Failed to send invite SMS.',
+          });
+        }
+      }
+
+      return res.status(201).json({
+        ok: true,
+        invite,
+        url: inviteUrl,
+      });
+    } catch (error) {
+      console.error(
+        'people invite create failed',
+        error
+      );
+
+      return res.status(500).json({
+        error: 'Failed to create invite.',
+      });
+    }
+  }
+);
 
 // GET /people-invites/:code
 router.get("/:code", async (req, res) => {

--- a/server/routes/randomChats.js
+++ b/server/routes/randomChats.js
@@ -71,7 +71,7 @@ async function buildRiaReply({ user, text }) {
   let history = [];
   if (remember && user?.id) {
     try {
-      history = await prisma.foriaMessage.findMany({
+      history = await prisma.riaMessage.findMany({
         where: { userId: user.id },
         orderBy: { createdAt: 'asc' },
         take: 20,
@@ -135,7 +135,7 @@ You are Ria, a friendly chat companion inside the Chatforia app.
   // 3) Persist this turn ONLY if remember is on
   if (remember && user?.id) {
     try {
-      await prisma.foriaMessage.createMany({
+      await prisma.riaMessage.createMany({
         data: [
           { userId: user.id, role: 'user', content: text },
           { userId: user.id, role: 'assistant', content: replyText },
@@ -381,10 +381,10 @@ router.get('/id/:id', requireAuth, async (req, res) => {
 });
 
 // 🧹 Clear Ria memory for the current user
-// (still stored in prisma.foriaMessage table)
+// (still stored in prisma.riaMessage table)
 router.delete('/ria/memory', requireAuth, async (req, res) => {
   try {
-    await prisma.foriaMessage.deleteMany({
+    await prisma.riaMessage.deleteMany({
       where: { userId: req.user.id },
     });
     res.json({ ok: true });

--- a/server/routes/video.js
+++ b/server/routes/video.js
@@ -77,6 +77,7 @@ try {
 
 try {
   await sendPushToUser(calleeId, {
+    skipApns: true,
     alert: {
       title: 'Incoming video call',
       body: `${callerName} is calling`,

--- a/server/routes/voiceWebhooks.js
+++ b/server/routes/voiceWebhooks.js
@@ -297,6 +297,78 @@ router.post('/inbound-app-complete', async (req, res) => {
 
 
 
+/**
+ * Twilio child Client progress callback.
+ *
+ * Twilio sends the answered event when the recipient's Voice SDK
+ * client actually accepts the call. This is the authoritative moment
+ * for changing the app-to-app call from ringing to ACTIVE.
+ */
+router.post('/app-call-progress', async (req, res) => {
+  try {
+    const backendCallId = Number(
+      req.query?.backendCallId ||
+      req.body?.backendCallId
+    );
+
+    const callStatus = String(
+      req.body?.CallStatus || ''
+    ).toLowerCase();
+
+    if (
+      !Number.isInteger(backendCallId) ||
+      backendCallId <= 0
+    ) {
+      return res.status(204).end();
+    }
+
+    if (
+      callStatus !== 'in-progress' &&
+      callStatus !== 'answered'
+    ) {
+      return res.status(204).end();
+    }
+
+    const result = await prisma.call.updateMany({
+      where: {
+        id: backendCallId,
+        status: {
+          notIn: [
+            'DECLINED',
+            'ENDED',
+            'FAILED',
+            'MISSED',
+          ],
+        },
+      },
+      data: {
+        status: 'ACTIVE',
+        startedAt: new Date(),
+      },
+    });
+
+    console.log(
+      '[voice/app-call-progress] answered',
+      {
+        backendCallId,
+        callStatus,
+        updated: result.count,
+      }
+    );
+
+    return res.status(204).end();
+  } catch (error) {
+    console.error(
+      '[voice/app-call-progress] failed',
+      {
+        error: error?.message || error,
+      }
+    );
+
+    return res.status(500).end();
+  }
+});
+
 router.post('/app-call-complete', async (req, res) => {
   const twiml = new VoiceResponse();
 
@@ -381,22 +453,14 @@ router.post('/app-call-complete', async (req, res) => {
       ];
 
       const canContinueToVoicemailFromTerminalState =
-        (
-          existingStatus === 'DECLINED' &&
-          ['busy', 'no-answer'].includes(dialCallStatus)
-        ) ||
-        (
-          existingStatus === 'MISSED' &&
-          dialCallStatus === 'no-answer'
-        );
+        existingStatus === 'MISSED' &&
+        dialCallStatus === 'no-answer';
 
       if (terminalStatuses.includes(existingStatus)) {
         relatedCallId = existing.id;
 
-        // The app may finalize DECLINED or MISSED before Twilio's Dial
-        // callback arrives. Preserve that first terminal state, but still
-        // continue the caller into voicemail for an explicit decline or
-        // a normal unanswered timeout.
+        // Explicit decline is terminal and must hang up immediately.
+        // Only a genuinely missed, unanswered call may enter voicemail.
         if (!canContinueToVoicemailFromTerminalState) {
           twiml.hangup();
           return res.type('text/xml').send(twiml.toString());
@@ -410,7 +474,7 @@ router.post('/app-call-complete', async (req, res) => {
           endReason = 'no_answer';
         } else if (dialCallStatus === 'busy') {
           status = 'DECLINED';
-          endReason = 'declined_to_voicemail';
+          endReason = 'declined';
         } else if (dialCallStatus === 'failed') {
           status = 'FAILED';
           endReason = 'failed';
@@ -476,10 +540,8 @@ router.post('/app-call-complete', async (req, res) => {
       return res.type('text/xml').send(twiml.toString());
     }
 
-    const shouldOfferVoicemail = [
-      'no-answer',
-      'busy',
-    ].includes(dialCallStatus);
+    const shouldOfferVoicemail =
+      dialCallStatus === 'no-answer';
 
     if (!shouldOfferVoicemail || !validCalleeUserId) {
       twiml.hangup();
@@ -656,7 +718,24 @@ router.post('/client', async (req, res) => {
         method: 'POST',
       });
 
-      dial.client(`user_${numericUserId}`);
+      const clientOptions = {};
+
+      if (
+        Number.isInteger(appBackendCallId) &&
+        appBackendCallId > 0
+      ) {
+        clientOptions.statusCallback =
+          `/webhooks/voice/app-call-progress` +
+          `?backendCallId=${appBackendCallId}`;
+
+        clientOptions.statusCallbackEvent = 'answered';
+        clientOptions.statusCallbackMethod = 'POST';
+      }
+
+      dial.client(
+        clientOptions,
+        `user_${numericUserId}`
+      );
 
       return res.type('text/xml').send(twiml.toString());
     }

--- a/server/routes/webhooksTwilio.js
+++ b/server/routes/webhooksTwilio.js
@@ -368,6 +368,36 @@ r.post(
       const storedTo =
         normalizedDid || String(did || '').trim();
 
+      let fromDisplayName = null;
+
+      const internalCallerMatch =
+        storedFrom.match(
+          /^(?:app:|client:)user_(\d+)$/i
+        );
+
+      if (internalCallerMatch) {
+        const internalCallerId =
+          Number(internalCallerMatch[1]);
+
+        if (Number.isInteger(internalCallerId)) {
+          const internalCaller =
+            await prisma.user.findUnique({
+              where: {
+                id: internalCallerId,
+              },
+              select: {
+                displayName: true,
+                username: true,
+              },
+            });
+
+          fromDisplayName =
+            internalCaller?.displayName?.trim() ||
+            internalCaller?.username?.trim() ||
+            null;
+        }
+      }
+
       if (!storedFrom || !storedTo) {
         console.error('[voicemail] invalid caller or destination');
         return;
@@ -404,6 +434,7 @@ r.post(
         void sendVoicemailForwardEmail({
           toEmail: forwardEmail,
           fromNumber: voicemail.fromNumber,
+          fromDisplayName,
           toNumber: voicemail.toNumber,
           transcript: null,
           audioUrl: voicemail.audioUrl,

--- a/server/services/__tests__/randomChatService.test.js
+++ b/server/services/__tests__/randomChatService.test.js
@@ -99,21 +99,34 @@ describe('enqueue and removeFromQueue', () => {
 });
 
 describe('createRandomRoom', () => {
-  it('calls prisma.randomChatRoom.create with correct data and returns room', async () => {
+  it('creates the linked chat rooms in a transaction and returns the canonical room', async () => {
+    const chatRoomCreate = jest.fn().mockResolvedValue({
+      id: 'room-123',
+    });
+
+    const randomChatRoomCreate = jest.fn().mockResolvedValue({
+      id: 'random-room-123',
+      participants: [{ id: 'user1' }, { id: 'user2' }],
+      messages: [
+        {
+          id: 'msg-1',
+          rawContent: "You've been paired for a random chat. Be kind!",
+          sender: { id: 'user1' },
+        },
+      ],
+    });
+
     const prisma = {
-      randomChatRoom: {
-        create: jest.fn().mockResolvedValue({
-          id: 'room-123',
-          participants: [{ id: 'user1' }, { id: 'user2' }],
-          messages: [
-            {
-              id: 'msg-1',
-              content: "You've been paired for a random chat. Be kind!",
-              sender: { id: 'user1' },
-            },
-          ],
+      $transaction: jest.fn(async (callback) =>
+        callback({
+          chatRoom: {
+            create: chatRoomCreate,
+          },
+          randomChatRoom: {
+            create: randomChatRoomCreate,
+          },
         }),
-      },
+      ),
     };
 
     const userA = { userId: 'user1', username: 'Alice' };
@@ -121,19 +134,48 @@ describe('createRandomRoom', () => {
 
     const room = await createRandomRoom(prisma, userA, userB);
 
-    expect(prisma.randomChatRoom.create).toHaveBeenCalledTimes(1);
+    expect(prisma.$transaction).toHaveBeenCalledTimes(1);
+    expect(chatRoomCreate).toHaveBeenCalledTimes(1);
+    expect(randomChatRoomCreate).toHaveBeenCalledTimes(1);
 
-    const call = prisma.randomChatRoom.create.mock.calls[0][0];
+    expect(chatRoomCreate).toHaveBeenCalledWith({
+      data: {
+        isGroup: false,
+        participants: {
+          create: [
+            {
+              user: { connect: { id: 'user1' } },
+              role: 'MEMBER',
+            },
+            {
+              user: { connect: { id: 'user2' } },
+              role: 'MEMBER',
+            },
+          ],
+        },
+      },
+    });
+
+    const call = randomChatRoomCreate.mock.calls[0][0];
 
     expect(call).toMatchObject({
       data: {
+        chatRoom: {
+          connect: { id: 'room-123' },
+        },
         participants: {
           connect: [{ id: 'user1' }, { id: 'user2' }],
         },
         messages: {
           create: [
             {
-              content: "You've been paired for a random chat. Be kind!",
+              rawContent: "You've been paired for a random chat. Be kind!",
+              sender: {
+                connect: { id: 'user1' },
+              },
+              chatRoom: {
+                connect: { id: 'room-123' },
+              },
             },
           ],
         },
@@ -144,13 +186,19 @@ describe('createRandomRoom', () => {
       },
     });
 
-    expect(room).toEqual({
+    expect(room).toMatchObject({
       id: 'room-123',
+      chatRoomId: 'room-123',
+      randomChatRoomId: 'random-room-123',
+      aliasByUser: {
+        user1: expect.any(String),
+        user2: expect.any(String),
+      },
       participants: [{ id: 'user1' }, { id: 'user2' }],
       messages: [
         {
           id: 'msg-1',
-          content: "You've been paired for a random chat. Be kind!",
+          rawContent: "You've been paired for a random chat. Be kind!",
           sender: { id: 'user1' },
         },
       ],
@@ -265,13 +313,25 @@ describe('tryMatch', () => {
     const queues = buildQueues();
 
     const prisma = {
-      randomChatRoom: {
-        create: jest.fn().mockResolvedValue({
-          id: 'room-999',
-          participants: [{ id: 'user-1' }, { id: 'user-2' }],
-          messages: [],
-        }),
+      contact: {
+        findUnique: jest.fn().mockResolvedValue(null),
       },
+      $transaction: jest.fn(async (callback) =>
+        callback({
+          chatRoom: {
+            create: jest.fn().mockResolvedValue({
+              id: 'room-999',
+            }),
+          },
+          randomChatRoom: {
+            create: jest.fn().mockResolvedValue({
+              id: 'random-room-999',
+              participants: [{ id: 'user-1' }, { id: 'user-2' }],
+              messages: [],
+            }),
+          },
+        }),
+      ),
     };
 
     const peerEntry = {
@@ -324,6 +384,8 @@ describe('tryMatch', () => {
     expect(result).toEqual({
       matched: true,
       roomId: 'room-999',
+      chatRoomId: 'room-999',
+      randomChatRoomId: 'random-room-999',
       myAlias: expect.any(String),
       partnerAlias: expect.any(String),
     });
@@ -333,12 +395,14 @@ describe('tryMatch', () => {
 
     expect(queues.activeRoomBySocket.get('sock-current')).toEqual({
       roomId: 'room-999',
+      randomChatRoomId: 'random-room-999',
       peerSocketId: 'sock-peer',
       peerUserId: 'user-2',
     });
 
     expect(queues.activeRoomBySocket.get('sock-peer')).toEqual({
       roomId: 'room-999',
+      randomChatRoomId: 'random-room-999',
       peerSocketId: 'sock-current',
       peerUserId: 'user-1',
     });
@@ -358,12 +422,16 @@ describe('tryMatch', () => {
       roomId: 'room-999',
       myAlias: expect.any(String),
       partnerAlias: expect.any(String),
+      partnerDisplayName: expect.any(String),
+      relationshipStatus: 'none',
     });
 
     expect(socketPeer.emit).toHaveBeenCalledWith('random:matched', {
       roomId: 'room-999',
       myAlias: expect.any(String),
       partnerAlias: expect.any(String),
+      partnerDisplayName: expect.any(String),
+      relationshipStatus: 'none',
     });
   });
 });

--- a/server/services/__tests__/riaService.test.js
+++ b/server/services/__tests__/riaService.test.js
@@ -6,8 +6,22 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 const promptBuilderPath = path.resolve(__dirname, '../promptBuilder.js');
+const prismaClientPath = path.resolve(
+  __dirname,
+  '../../utils/prismaClient.js'
+);
 
 const createMock = jest.fn();
+
+const prismaMock = {
+  user: {
+    findUnique: jest.fn(),
+  },
+  riaMessage: {
+    findMany: jest.fn(),
+    createMany: jest.fn(),
+  },
+};
 
 jest.unstable_mockModule('openai', () => ({
   __esModule: true,
@@ -27,6 +41,11 @@ jest.unstable_mockModule(promptBuilderPath, () => ({
   buildChatPrompt: jest.fn(),
 }));
 
+jest.unstable_mockModule(prismaClientPath, () => ({
+  __esModule: true,
+  default: prismaMock,
+}));
+
 const {
   suggestReplies,
   rewriteText,
@@ -43,6 +62,15 @@ describe('riaService', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     createMock.mockReset();
+
+    prismaMock.user.findUnique.mockResolvedValue({
+      riaRemember: true,
+    });
+    prismaMock.riaMessage.findMany.mockResolvedValue([]);
+    prismaMock.riaMessage.createMany.mockResolvedValue({
+      count: 2,
+    });
+
     process.env.OPENAI_API_KEY = 'test-openai-key';
     delete process.env.OPENAI_MODEL;
   });

--- a/server/services/__tests__/voiceBridge.test.js
+++ b/server/services/__tests__/voiceBridge.test.js
@@ -12,12 +12,20 @@ process.env.TWILIO_VOICE_STATUS_CALLBACK_URL =
 // --- Prisma mock -------------------------------------------------------------
 
 const mockUserFindUnique = jest.fn();
+const mockCallFindFirst = jest.fn();
+const mockCallFindUnique = jest.fn();
+const mockCallCreate = jest.fn();
 
 jest.unstable_mockModule('../utils/prismaClient.js', () => ({
   __esModule: true,
   default: {
     user: {
       findUnique: mockUserFindUnique,
+    },
+    call: {
+      findFirst: mockCallFindFirst,
+      findUnique: mockCallFindUnique,
+      create: mockCallCreate,
     },
   },
 }));
@@ -50,6 +58,17 @@ const { startAliasCall } = await import('../voiceBridge.js');
 beforeEach(() => {
   jest.clearAllMocks();
   mockUserFindUnique.mockReset();
+  mockCallFindFirst
+    .mockReset()
+    .mockResolvedValue(null);
+  mockCallFindUnique
+    .mockReset()
+    .mockResolvedValue(null);
+  mockCallCreate
+    .mockReset()
+    .mockResolvedValue({
+      id: 777,
+    });
   mockCallsCreate.mockReset();
 });
 
@@ -165,6 +184,8 @@ describe('startAliasCall', () => {
       userPhone,
       stage: 'legA-dialing',
       callSid: 'CA1234567890',
+      callId: 777,
+      resolvedCallId: 777,
     });
 
     expect(mockTwilioCtor).toHaveBeenCalledWith(

--- a/server/services/pushService.js
+++ b/server/services/pushService.js
@@ -204,7 +204,15 @@ export async function sendVoipCallPushToUser(userId, payload) {
   note.topic = process.env.APNS_VOIP_TOPIC || `${process.env.APNS_TOPIC}.voip`;
   note.pushType = 'voip';
   note.priority = 10;
-  note.expiry = Math.floor(Date.now() / 1000) + 60;
+  note.expiry = 0;
+
+  // apn@2.2.0 omits the apns-expiration header when expiry is 0.
+  // Force the literal header so APNs does not persist stale call invitations.
+  const originalHeaders = note.headers.bind(note);
+  note.headers = () => ({
+    ...originalHeaders(),
+    'apns-expiration': 0,
+  });
 
   note.payload = {
     type: 'call_incoming',
@@ -260,7 +268,7 @@ export async function sendPushToUser(userId, payload) {
     fcm: null,
   };
 
-  if (tokens.apns.length) {
+  if (!payload.skipApns && tokens.apns.length && payload.alert) {
     const apnProvider = getProvider();
 
     if (apnProvider) {
@@ -319,6 +327,12 @@ export async function sendPushToUser(userId, payload) {
 
       const isMissedCall = stringData.type === 'call_missed';
       const isIncomingCall = stringData.type === 'call_incoming';
+      const isEndedCall = stringData.type === 'call_ended';
+
+      const lifecycleCollapseKey =
+        stringData.callId && (isIncomingCall || isEndedCall)
+          ? `chatforia_call_${stringData.callId}`
+          : undefined;
 
       stringData.title = payload.alert?.title || stringData.senderName || 'Chatforia';
       stringData.body = payload.alert?.body || 'New message';
@@ -328,10 +342,27 @@ export async function sendPushToUser(userId, payload) {
         data: stringData,
         android: {
           priority: 'high',
+
           ...(isIncomingCall
             ? {
-                // Do not retain live-call invitations after the call window.
+                // A ringing invitation is useful only while the call is live.
                 ttl: 30_000,
+              }
+            : {}),
+
+          ...(isEndedCall
+            ? {
+                // Keep terminal cancellation available long enough to replace
+                // a queued incoming invitation.
+                ttl: 60_000,
+              }
+            : {}),
+
+          ...(lifecycleCollapseKey
+            ? {
+                // Incoming and terminal events for one call replace one
+                // another while queued by FCM.
+                collapseKey: lifecycleCollapseKey,
               }
             : {}),
         },

--- a/server/services/riaService.js
+++ b/server/services/riaService.js
@@ -1,4 +1,5 @@
 import OpenAI from 'openai';
+import prisma from '../utils/prismaClient.js';
 import {
   buildSuggestRepliesPrompt,
   buildRewritePrompt,
@@ -90,18 +91,90 @@ export async function chatWithRia({
   memoryEnabled = true,
   filterProfanity = false,
 }) {
+  const memoryPreference =
+    userId
+      ? await prisma.user.findUnique({
+          where: {
+            id: Number(userId),
+          },
+          select: {
+            riaRemember: true,
+          },
+        })
+      : null;
+
+  const effectiveMemoryEnabled =
+    Boolean(memoryEnabled) &&
+    memoryPreference?.riaRemember !== false;
+
+  const latestUserMessage =
+    [...messages]
+      .reverse()
+      .find((message) => message.role === 'user');
+
+  let promptMessages = messages;
+
+  if (effectiveMemoryEnabled && userId) {
+    const storedDescending =
+      await prisma.riaMessage.findMany({
+        where: {
+          userId: Number(userId),
+        },
+        orderBy: {
+          createdAt: 'desc',
+        },
+        take: 40,
+        select: {
+          role: true,
+          content: true,
+        },
+      });
+
+    promptMessages = storedDescending.reverse();
+
+    if (latestUserMessage) {
+      promptMessages.push(latestUserMessage);
+    }
+  }
+
   const prompt = buildChatPrompt({
     userId,
     username,
     displayName,
-    messages,
-    memoryEnabled,
+    messages: promptMessages,
+    memoryEnabled: effectiveMemoryEnabled,
   });
 
   const raw = await chatText(prompt, 220);
-  const reply = maybeMaskText(String(raw || '').trim(), filterProfanity);
+
+  const reply =
+    maybeMaskText(
+      String(raw || '').trim(),
+      filterProfanity
+    ) || "I'm here with you.";
+
+  if (
+    effectiveMemoryEnabled &&
+    userId &&
+    latestUserMessage?.content
+  ) {
+    await prisma.riaMessage.createMany({
+      data: [
+        {
+          userId: Number(userId),
+          role: 'user',
+          content: latestUserMessage.content,
+        },
+        {
+          userId: Number(userId),
+          role: 'assistant',
+          content: reply,
+        },
+      ],
+    });
+  }
 
   return {
-    reply: reply || "I'm here with you.",
+    reply,
   };
 }

--- a/server/services/voicemailEmail.js
+++ b/server/services/voicemailEmail.js
@@ -4,6 +4,7 @@ import { sendMail } from '../utils/sendMail.js';
 export async function sendVoicemailForwardEmail({
   toEmail,
   fromNumber,
+  fromDisplayName,
   toNumber,
   transcript,
   audioUrl,
@@ -15,13 +16,22 @@ export async function sendVoicemailForwardEmail({
     return;
   }
 
-  const subject = `New voicemail from ${fromNumber || 'Unknown caller'}`;
+  const callerLabel =
+    String(
+      fromDisplayName ||
+      fromNumber ||
+      'Unknown caller'
+    )
+      .replace(/[\r\n]+/g, ' ')
+      .trim() || 'Unknown caller';
+
+  const subject = `New voicemail from ${callerLabel}`;
   const created = createdAt ? new Date(createdAt) : new Date();
 
   const plainLines = [
     `You have a new voicemail in Chatforia.`,
     '',
-    `From: ${fromNumber || 'Unknown caller'}`,
+    `From: ${callerLabel}`,
     `To:   ${toNumber || 'Your Chatforia number'}`,
     `Time: ${created.toLocaleString()}`,
   ];
@@ -43,7 +53,7 @@ export async function sendVoicemailForwardEmail({
   const html = `
     <p>You have a new voicemail in <strong>Chatforia</strong>.</p>
     <ul>
-      <li><strong>From:</strong> ${fromNumber || 'Unknown caller'}</li>
+      <li><strong>From:</strong> ${escapeHtml(callerLabel)}</li>
       <li><strong>To:</strong> ${toNumber || 'Your Chatforia number'}</li>
       <li><strong>Time:</strong> ${created.toLocaleString()}</li>
       ${


### PR DESCRIPTION
This update consolidates the backend reliability work for Chatforia calling, Ria memory, voicemail forwarding, and People Invite SMS delivery.

### Call lifecycle and push reliability

* Arbitrates simultaneous reciprocal calls so competing requests resolve to one canonical backend call.
* Cleans up stale pre-answer call records before creating a new call.
* Preserves canonical call IDs across app, Twilio Voice, video, socket, and push flows.
* Adds a lightweight authenticated call-status endpoint for rejecting stale incoming-call pushes.
* Marks calls active when Twilio confirms that the recipient actually answered.
* Preserves terminal call states and prevents late callbacks from overwriting the winning result.
* Sends terminal `call_ended` lifecycle pushes to clear queued incoming-call invitations.
* Uses matching FCM collapse keys for incoming and terminal events belonging to the same call.
* Applies short Android TTL values to time-sensitive call events.
* Forces `apns-expiration: 0` for VoIP invitations so APNs does not retain stale incoming calls.
* Supports skipping standard APNs alerts when the VoIP or lifecycle path already handles delivery.
* Ensures explicit decline, provider failure, and caller cancellation do not incorrectly enter voicemail.
* Preserves voicemail only for genuinely missed and unanswered calls.
* Improves Twilio backend-call association and protects against duplicate Twilio SID ownership.

### Ria memory

* Persists Ria conversations in the database when the user’s memory preference is enabled.
* Uses the server-side `riaRemember` preference as the authoritative privacy control.
* Prevents clients from overriding a disabled server-side memory preference.
* Loads recent Ria history for the authenticated user while maintaining account isolation.
* Renames the physical `ForiaMessage` table, indexes, and foreign-key constraint to `RiaMessage`.
* Includes the database migration required for the rename.
* Updates Ria and Random Chat tests for transactional room creation, canonical room identifiers, contact relationships, and Prisma-backed memory.

### Voicemail forwarding

* Improves voicemail-to-call association.
* Resolves internal app caller identifiers to the caller’s display name or username in forwarded voicemail email.
* Retains safe fallback formatting when no user identity can be resolved.

### People Invite SMS delivery

* Validates and normalizes invite destinations.
* Prevents users from sending SMS invitations to their own number.
* Adds delivery safeguards and rate limiting.
* Revokes invitations when SMS delivery fails.
* Improves invite preview, redemption, expiration, and error handling.
* Updates Twilio telco-driver coverage for Messaging Service and fallback-number delivery.

### Validation

* Prisma schema validation passed.
* 9 call, voice, and voicemail suites passed: 71 tests.
* 3 Ria and Random Chat suites passed: 40 tests.
* 4 People Invite, telco, and phone-verification suites passed: 37 tests.
* Total targeted backend validation: 16 suites and 148 tests passed.
* Live iPhone and Android audio/video call behavior was verified.
* Ria memory and account isolation were verified across the website, iOS, and Android.
* Explicit decline behavior was verified to end calls without creating voicemail.
* Voicemail forwarding display-name behavior was verified.
