### PR TITLE
fix: classify expected client errors for Sentry

### DIFF
--- a/server/__tests__/calls.routes.test.js
+++ b/server/__tests__/calls.routes.test.js
@@ -182,6 +182,25 @@ describe('calls routes', () => {
         resolvedCallId: 123,
       });
 
+      expect(
+        mockPrisma.$executeRaw
+      ).toHaveBeenCalledTimes(1);
+
+      const [
+        sqlParts,
+        lowUserId,
+        highUserId,
+      ] = mockPrisma.$executeRaw.mock.calls[0];
+
+      expect(
+        sqlParts.join('?')
+      ).toMatch(
+        /pg_advisory_xact_lock\s*\(\s*CAST\(\? AS integer\),\s*CAST\(\? AS integer\)\s*\)/
+      );
+
+      expect(lowUserId).toBe(10);
+      expect(highUserId).toBe(20);
+
       expect(mockPrisma.call.create).toHaveBeenCalledWith({
         data: {
           callerId: 10,

--- a/server/app.js
+++ b/server/app.js
@@ -10,6 +10,9 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 
 import authMiddleware from './middleware/auth.js';
+import {
+  createCorsForbiddenError,
+} from './middleware/cors.js';
 
 import translateRoutes from "./routes/translate.js";
 
@@ -224,7 +227,9 @@ export function createApp() {
         }
 
         console.log('❌ CORS BLOCKED:', origin);
-        return callback(new Error('Not allowed by CORS'));
+        return callback(
+          createCorsForbiddenError()
+        );
       },
       credentials: true,
     })

--- a/server/middleware/__tests__/audit.test.js
+++ b/server/middleware/__tests__/audit.test.js
@@ -268,4 +268,84 @@ describe('audit middleware suite', () => {
       expect(next).toHaveBeenCalledTimes(1);
     }
   });
+
+  test('shouldCaptureSentryError(): skips expected 4xx errors', async () => {
+    const { mod } = await loadModule();
+
+    expect(
+      mod.shouldCaptureSentryError({
+        statusCode: 400,
+      })
+    ).toBe(false);
+
+    expect(
+      mod.shouldCaptureSentryError({
+        statusCode: 401,
+        code: 'GOOGLE_PLAY_RTDN_TOKEN_REQUIRED',
+      })
+    ).toBe(false);
+
+    expect(
+      mod.shouldCaptureSentryError({
+        status: 403,
+      })
+    ).toBe(false);
+
+    expect(
+      mod.shouldCaptureSentryError({
+        output: {
+          statusCode: 404,
+        },
+      })
+    ).toBe(false);
+  });
+
+  test('shouldCaptureSentryError(): captures server and unknown errors', async () => {
+    const { mod } = await loadModule();
+
+    expect(
+      mod.shouldCaptureSentryError({
+        statusCode: 500,
+      })
+    ).toBe(true);
+
+    expect(
+      mod.shouldCaptureSentryError({
+        statusCode: 503,
+      })
+    ).toBe(true);
+
+    expect(
+      mod.shouldCaptureSentryError(
+        new Error('Unexpected failure')
+      )
+    ).toBe(true);
+  });
+
+  test('sentryErrorHandler(): always forwards the original error', async () => {
+    const { mod } = await loadModule();
+    const { req, res, next } =
+      makeReqResNext();
+
+    const error = Object.assign(
+      new Error(
+        'A valid Pub/Sub bearer token is required.'
+      ),
+      {
+        statusCode: 401,
+        code: 'GOOGLE_PLAY_RTDN_TOKEN_REQUIRED',
+      }
+    );
+
+    mod.sentryErrorHandler(
+      error,
+      req,
+      res,
+      next
+    );
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledWith(error);
+  });
+
 });

--- a/server/middleware/__tests__/cors.test.js
+++ b/server/middleware/__tests__/cors.test.js
@@ -1,0 +1,20 @@
+import {
+  createCorsForbiddenError,
+} from '../cors.js';
+
+describe('CORS errors', () => {
+  test('classifies a rejected origin as an expected 403', () => {
+    const error =
+      createCorsForbiddenError();
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error.message).toBe(
+      'Not allowed by CORS'
+    );
+    expect(error.status).toBe(403);
+    expect(error.statusCode).toBe(403);
+    expect(error.code).toBe(
+      'CORS_ORIGIN_FORBIDDEN'
+    );
+  });
+});

--- a/server/middleware/audit.js
+++ b/server/middleware/audit.js
@@ -65,10 +65,29 @@ export function sentryRequestHandler(req, _res, next) {
   return next();
 }
 
+export function shouldCaptureSentryError(err) {
+  const statusCode = Number(
+    err?.statusCode ||
+    err?.status ||
+    err?.output?.statusCode
+  );
+
+  const isExpectedClientError =
+    Number.isInteger(statusCode) &&
+    statusCode >= 400 &&
+    statusCode < 500;
+
+  return !isExpectedClientError;
+}
+
 export function sentryErrorHandler(err, _req, _res, next) {
-  if (sentryEnabled) {
+  if (
+    sentryEnabled &&
+    shouldCaptureSentryError(err)
+  ) {
     Sentry.captureException(err);
   }
+
   return next(err);
 }
 

--- a/server/middleware/cors.js
+++ b/server/middleware/cors.js
@@ -7,6 +7,18 @@ function parseList(v) {
     .filter(Boolean);
 }
 
+export function createCorsForbiddenError() {
+  const error = new Error(
+    'Not allowed by CORS'
+  );
+
+  error.status = 403;
+  error.statusCode = 403;
+  error.code = 'CORS_ORIGIN_FORBIDDEN';
+
+  return error;
+}
+
 export function corsConfigured() {
   const devOrigins = ['http://localhost:5173', 'http://127.0.0.1:5173'];
   const extra = parseList(process.env.CORS_EXTRA_ORIGINS);


### PR DESCRIPTION
## Summary

* Prevent expected HTTP 4xx client errors from being captured as Sentry server failures
* Classify blocked CORS origins as HTTP 403 errors
* Preserve forwarding of all errors to the normal Express error handler
* Continue capturing unknown errors and HTTP 5xx failures
* Add regression coverage for Google Play RTDN authentication failures, CORS rejections, and PostgreSQL advisory-lock argument casting

## Verification

* 5 test suites passed
* 43 tests passed
* `git diff --cached --check` passed
* Confirmed the current production advisory-lock query succeeds
* Confirmed the RiaMessage production migration completed successfully
