### PR TITLE
Fix multi-device call routing and answer arbitration

### DIFF
--- a/client/src/components/ContactList.jsx
+++ b/client/src/components/ContactList.jsx
@@ -23,6 +23,7 @@ import {
   IconVideo,
 } from '@tabler/icons-react';
 import { useTranslation } from 'react-i18next';
+import { useCall } from '@/context/CallContext';
 
 // --- tiny, safe toast fallback so we don't crash if your toast util isn't wired yet
 const toast = {
@@ -48,6 +49,8 @@ export default function ContactList({
 }) {
   const { t, i18n } = useTranslation();
   const navigate = useNavigate();
+const callContext = useCall();
+const startCall = callContext?.startCall;
 
   const [items, setItems] = useState([]);
   const [nextCursor, setNextCursor] = useState(null);
@@ -171,19 +174,98 @@ export default function ContactList({
    * Your Dialer/Video pages should be driven by `?to=E164...`
    * (NOT `userId=...`)
    */
-  const goCall = ({ userId, phone }) => {
-  if (userId) return navigate(`/dialer?userId=${encodeURIComponent(userId)}`);
+  const goCall = async ({
+  userId,
+  phone,
+  alias,
+}) => {
+  if (userId) {
+    if (!startCall) {
+      toast.err(
+        t(
+          'contactList.callUnavailable',
+          'Calling is temporarily unavailable.'
+        )
+      );
+      return;
+    }
+
+    try {
+      await startCall({
+        calleeId: Number(userId),
+        mode: 'AUDIO',
+        peerName: alias,
+      });
+    } catch (error) {
+      toast.err(
+        error?.message ||
+          t(
+            'contactList.callFailed',
+            'Could not start audio call.'
+          )
+      );
+    }
+
+    return;
+  }
+
   const to = normalizePhone(phone);
-  if (!to) return toast.info('No callable number');
+
+  if (!to) {
+    toast.info(
+      t(
+        'contactList.noCallableNumber',
+        'No callable number.'
+      )
+    );
+    return;
+  }
+
   navigate(`/dialer?to=${encodeURIComponent(to)}`);
 };
 
-  const goVideo = ({ userId }) => {
-    if (!userId) return toast.info(t('contactList.videoRequiresAccount', 'Video requires a Chatforia account'));
-    navigate(`/video?userId=${encodeURIComponent(userId)}`);
-  };
+const goVideo = async ({
+  userId,
+  alias,
+}) => {
+  if (!userId) {
+    toast.info(
+      t(
+        'contactList.videoRequiresAccount',
+        'Video requires a Chatforia account'
+      )
+    );
+    return;
+  }
 
-  const openSmsThreadOrCompose = async ({ phone, alias }) => {
+  if (!startCall) {
+    toast.err(
+      t(
+        'contactList.callUnavailable',
+        'Calling is temporarily unavailable.'
+      )
+    );
+    return;
+  }
+
+  try {
+    await startCall({
+      calleeId: Number(userId),
+      mode: 'VIDEO',
+      peerName: alias,
+    });
+  } catch (error) {
+    toast.err(
+      error?.message ||
+        t(
+          'contactList.videoCallFailed',
+          'Could not start video call.'
+        )
+    );
+  }
+};
+
+const openSmsThreadOrCompose = async ({ phone, alias }) => {
     if (!phone) return;
 
     const to = String(phone).trim();

--- a/client/src/components/routes/Dialer.jsx
+++ b/client/src/components/routes/Dialer.jsx
@@ -110,7 +110,6 @@ export default function Dialer() {
   const [params] = useSearchParams();
 
   const qpTo = params.get('to');
-  const qpUserId = params.get('userId');
 
   const [digits, setDigits] = useState('');
   const [resolving, setResolving] = useState(false);
@@ -165,55 +164,14 @@ export default function Dialer() {
   }, []);
 
   useEffect(() => {
-    let mounted = true;
+    setResolveError('');
 
-    async function run() {
-      setResolveError('');
-
-      if (qpTo) {
-        const next = normalizePhone(qpTo);
-        if (mounted) setDigits(next);
-        return;
-      }
-
-      if (qpUserId) {
-        const userId = String(qpUserId || '').trim();
-        if (!userId) return;
-
-        setResolving(true);
-        try {
-          const { data } = await axiosClient.get(
-            `/users/${encodeURIComponent(userId)}/call-target`
-          );
-
-          const to = normalizePhone(data?.to || '');
-          if (!to) {
-            throw new Error(
-              data?.error || 'No callable target for this user (missing phone number).'
-            );
-          }
-
-          if (mounted) setDigits(to);
-        } catch (e) {
-          console.error('Dialer: failed to resolve call target', e);
-          if (mounted) {
-            setResolveError(
-              e?.response?.data?.error ||
-                e?.message ||
-                t('dialer.resolveFailed', 'Could not resolve call target.')
-            );
-          }
-        } finally {
-          if (mounted) setResolving(false);
-        }
-      }
+    if (qpTo) {
+      setDigits(
+        normalizePhone(qpTo)
+      );
     }
-
-    run();
-    return () => {
-      mounted = false;
-    };
-  }, [qpTo, qpUserId, t]);
+  }, [qpTo]);
 
   const press = (d) => setDigits((s) => (s + d).slice(0, 32));
   const backspace = () => setDigits((s) => s.slice(0, -1));

--- a/client/src/context/CallContext.jsx
+++ b/client/src/context/CallContext.jsx
@@ -29,6 +29,17 @@ export function CallProvider({ children, me }) {
 
   const peerConnectionsRef = useRef({});
   const pcRef = useRef(null); // keep for backwards compatibility
+  const activeRef = useRef(null);
+  const incomingRef = useRef(null);
+  const answeringCallIdRef = useRef(null);
+
+  useEffect(() => {
+    activeRef.current = active;
+  }, [active]);
+
+  useEffect(() => {
+    incomingRef.current = incoming;
+  }, [incoming]);
   const [participants, setParticipants] = useState([]);
 
   // Keep local & remote streams for UI
@@ -85,7 +96,49 @@ export function CallProvider({ children, me }) {
     }
   }
 
-  function onEnded() {
+  function onEnded(payload) {
+    const eventCallId = payload?.callId;
+
+    const currentCallId =
+      activeRef.current?.callId ??
+      incomingRef.current?.callId;
+
+    if (
+      eventCallId == null ||
+      currentCallId == null ||
+      String(eventCallId) !==
+        String(currentCallId)
+    ) {
+      return;
+    }
+
+    const status =
+      String(payload?.status || '')
+        .trim()
+        .toUpperCase();
+
+    if (status === 'ANSWERED_ELSEWHERE') {
+      const isAnsweringHere =
+        answeringCallIdRef.current != null &&
+        String(answeringCallIdRef.current) ===
+          String(eventCallId);
+
+      const isAlreadyActiveHere =
+        activeRef.current?.callId != null &&
+        String(activeRef.current.callId) ===
+          String(eventCallId);
+
+      if (
+        isAnsweringHere ||
+        isAlreadyActiveHere
+      ) {
+        return;
+      }
+
+      cleanup();
+      return;
+    }
+
     cleanup();
   }
 
@@ -234,32 +287,77 @@ async function addParticipant(userId) {
    */
   async function startCallByUser({ calleeId, mode = 'VIDEO', peerName }) {
     if (!calleeId) throw new Error('Missing calleeId');
+
     setInviteHint(null);
     setPending(true);
 
-    const pc = await createPeer();
-    const local = await navigator.mediaDevices.getUserMedia({ video: mode === 'VIDEO', audio: true });
-    localStreamRef.current = local;
-    local.getTracks().forEach((t) => pc.addTrack(t, local));
+    try {
+      const pc = await createPeer();
 
-    const offer = await pc.createOffer();
-    await pc.setLocalDescription(offer);
+      const local =
+        await navigator.mediaDevices.getUserMedia({
+          video: mode === 'VIDEO',
+          audio: true,
+        });
 
-    const resp = await fetch(`${API_BASE}/calls/invite`, {
-      method: 'POST',
-      credentials: 'include',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ calleeId, mode, offer }),
-    });
+      localStreamRef.current = local;
+      local.getTracks().forEach((track) => {
+        pc.addTrack(track, local);
+      });
 
-    const data = await resp.json(); // { callId, peerId }
-    setActive({
-      callId: data.callId,
-      peerId: calleeId,
-      mode,
-      peerName,
-    });
-    return data;
+      const offer = await pc.createOffer();
+      await pc.setLocalDescription(offer);
+
+      const resp = await fetch(
+        `${API_BASE}/calls/invite`,
+        {
+          method: 'POST',
+          credentials: 'include',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            calleeId,
+            mode,
+            offer,
+          }),
+        }
+      );
+
+      const data =
+        await resp.json().catch(() => ({}));
+
+      if (!resp.ok) {
+        const error = new Error(
+          data?.message ||
+            data?.error ||
+            `Could not start call (${resp.status}).`
+        );
+
+        error.status = resp.status;
+        error.data = data;
+
+        throw error;
+      }
+
+      if (!data?.callId) {
+        throw new Error(
+          'The call server did not return a call ID.'
+        );
+      }
+
+      setActive({
+        callId: data.callId,
+        peerId: calleeId,
+        mode,
+        peerName,
+      });
+
+      return data;
+    } catch (error) {
+      cleanup();
+      throw error;
+    }
   }
 
   /**
@@ -377,20 +475,78 @@ async function addParticipant(userId) {
     const answer = await pc.createAnswer();
     await pc.setLocalDescription(answer);
 
-    await fetch(`${API_BASE}/calls/answer`, {
-      method: 'POST',
-      credentials: 'include',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ callId, answer }),
-    });
+    answeringCallIdRef.current = callId;
 
-    setActive({
+    let response;
+
+    try {
+      response = await fetch(
+        `${API_BASE}/calls/answer`,
+        {
+          method: 'POST',
+          credentials: 'include',
+          headers: {
+            'Content-Type':
+              'application/json',
+          },
+          body: JSON.stringify({
+            callId,
+            answer,
+          }),
+        }
+      );
+    } catch (error) {
+      answeringCallIdRef.current = null;
+      cleanup();
+      throw error;
+    }
+
+    const responseData =
+      await response
+        .json()
+        .catch(() => ({}));
+
+    if (response.ok === false) {
+      answeringCallIdRef.current = null;
+      cleanup();
+
+      if (
+        response.status === 409 &&
+        responseData?.code ===
+          'CALL_ANSWERED_ELSEWHERE'
+      ) {
+        return;
+      }
+
+      const error =
+        new Error(
+          responseData?.error ||
+          'Could not answer this call.'
+        );
+
+      error.code =
+        responseData?.code ||
+        null;
+
+      throw error;
+    }
+
+    const nextActive = {
       callId,
       peerId: fromUser?.id,
       mode,
       peerName,
-    });
+    };
 
+    /*
+     * Update the ref synchronously so a delayed
+     * answered-elsewhere event cannot land between
+     * the successful response and React's effect.
+     */
+    activeRef.current = nextActive;
+    setActive(nextActive);
+
+    answeringCallIdRef.current = null;
     setIncoming(null);
     setPending(false);
   }

--- a/client/src/context/__tests__/CallContext.test.js
+++ b/client/src/context/__tests__/CallContext.test.js
@@ -533,11 +533,140 @@ describe('CallContext', () => {
     });
 
     await act(async () => {
-      socketMock.emit('call:ended');
+      socketMock.emit('call:ended', {
+        callId: 'call-123',
+      });
     });
 
     expect(ctxRef.active).toBe(null);
     expect(ctxRef.incoming).toBe(null);
     expect(ctxRef.pcRef.current).toBe(null);
   });
+
+test(
+  'ignores answered-elsewhere while this browser answer is pending',
+  async () => {
+    renderWithProvider();
+
+    act(() => {
+      socketMock.emit('call:incoming', {
+        callId: 'answer-here-1',
+        fromUser: {
+          id: 24,
+        },
+        mode: 'AUDIO',
+        offer: {
+          type: 'offer',
+          sdp: 'incoming-offer',
+        },
+      });
+    });
+
+    let resolveAnswerResponse;
+
+    const answerResponse =
+      new Promise((resolve) => {
+        resolveAnswerResponse = resolve;
+      });
+
+    fetchMock
+      .mockImplementationOnce(async () => ({
+        ok: true,
+        json: async () => ({
+          iceServers: [],
+        }),
+      }))
+      .mockImplementationOnce(
+        async () => answerResponse
+      );
+
+    let acceptPromise;
+
+    await act(async () => {
+      acceptPromise = ctxRef.acceptCall();
+      await Promise.resolve();
+    });
+
+    act(() => {
+      socketMock.emit('call:ended', {
+        callId: 'answer-here-1',
+        status: 'ANSWERED_ELSEWHERE',
+      });
+    });
+
+    expect(ctxRef.incoming).not.toBe(null);
+    expect(ctxRef.pcRef.current).not.toBe(null);
+
+    resolveAnswerResponse({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        ok: true,
+        callId: 'answer-here-1',
+        status: 'ACTIVE',
+      }),
+    });
+
+    await act(async () => {
+      await acceptPromise;
+    });
+
+    expect(ctxRef.active).toEqual(
+      expect.objectContaining({
+        callId: 'answer-here-1',
+      })
+    );
+
+    expect(ctxRef.incoming).toBe(null);
+  }
+);
+
+test(
+  'cleans up when another device wins the answer claim',
+  async () => {
+    renderWithProvider();
+
+    act(() => {
+      socketMock.emit('call:incoming', {
+        callId: 'answered-elsewhere-1',
+        fromUser: {
+          id: 24,
+        },
+        mode: 'VIDEO',
+        offer: {
+          type: 'offer',
+          sdp: 'incoming-offer',
+        },
+      });
+    });
+
+    fetchMock
+      .mockImplementationOnce(async () => ({
+        ok: true,
+        json: async () => ({
+          iceServers: [],
+        }),
+      }))
+      .mockImplementationOnce(async () => ({
+        ok: false,
+        status: 409,
+        json: async () => ({
+          error:
+            'This call was answered on another device.',
+          code:
+            'CALL_ANSWERED_ELSEWHERE',
+        }),
+      }));
+
+    await act(async () => {
+      await ctxRef.acceptCall();
+    });
+
+    expect(ctxRef.active).toBe(null);
+    expect(ctxRef.incoming).toBe(null);
+    expect(ctxRef.pcRef.current).toBe(null);
+    expect(ctxRef.localStream.current).toBe(null);
+  }
+);
+
 });


### PR DESCRIPTION
Fixes the multi-device call lifecycle across the website, iOS, Android, and the API.

Website changes:
- Routes contact audio/video calls through the canonical app-call path.
- Removes the obsolete `/users/:id/call-target` lookup.
- Ignores stale lifecycle events from earlier calls.
- Handles first-answer arbitration and `CALL_ANSWERED_ELSEWHERE`.
- Cleans up losing browser instances without ending the winning call.

Verification:
- CallContext: 10 tests passed.
- Production Vite build succeeded.
- Backend arbitration/push tests: 3 suites and 9 tests passed.
- iOS device build succeeded.
- Android debug Kotlin compilation succeeded.