### PR TITLE
Fix chat search ad hook ordering

### DIFF
--- a/client/src/ads/AdSlot.jsx
+++ b/client/src/ads/AdSlot.jsx
@@ -120,18 +120,28 @@ export default function AdSlot({
     return houseFallback;
   }, [provider, placement, config, houseFallback]);
 
-  if (!placement || !canShow || !content) return null;
+  const shouldRender = Boolean(
+    placement &&
+      canShow &&
+      content
+  );
 
   useEffect(() => {
-    if (!lazy) {
-      if (markedRef.current) return;
-      markedRef.current = true;
-      markShown(placement, capKey);
-    }
-  }, [lazy, placement, capKey, markShown]);
+    if (!shouldRender || lazy) return;
+    if (markedRef.current) return;
+
+    markedRef.current = true;
+    markShown(placement, capKey);
+  }, [
+    shouldRender,
+    lazy,
+    placement,
+    capKey,
+    markShown,
+  ]);
 
   useEffect(() => {
-    if (!lazy) return;
+    if (!shouldRender || !lazy) return;
 
     const el = rootRef.current;
     if (!el) return;
@@ -152,7 +162,15 @@ export default function AdSlot({
 
     obs.observe(el);
     return () => obs.disconnect();
-  }, [lazy, placement, capKey, markShown]);
+  }, [
+    shouldRender,
+    lazy,
+    placement,
+    capKey,
+    markShown,
+  ]);
+
+  if (!shouldRender) return null;
 
   return (
     <Box

--- a/client/src/ads/__tests__/AdSlot.test.js
+++ b/client/src/ads/__tests__/AdSlot.test.js
@@ -1,0 +1,81 @@
+import React from 'react';
+import {
+  render,
+  screen,
+} from '@testing-library/react';
+
+import AdSlot from '../AdSlot.jsx';
+
+let mockCanShow = false;
+
+const mockMarkShown = jest.fn();
+
+jest.mock('@/ads/AdProvider', () => ({
+  useAds: () => ({
+    canShow: () => mockCanShow,
+    markShown: mockMarkShown,
+    provider: 'house',
+  }),
+}));
+
+jest.mock('@/ads/HouseAdSlot', () => ({
+  __esModule: true,
+  default: () => (
+    <div data-testid="house-ad">
+      House advertisement
+    </div>
+  ),
+}));
+
+jest.mock('@/ads/placements', () => ({
+  getPlacementConfig: () => ({
+    cap: {
+      coolMs: 0,
+    },
+  }),
+}));
+
+describe('AdSlot hook ordering', () => {
+  beforeEach(() => {
+    mockCanShow = false;
+    mockMarkShown.mockClear();
+  });
+
+  test(
+    'can transition between hidden and visible without changing hook order',
+    () => {
+      const { container, rerender } = render(
+        <AdSlot
+          placement="search_results_footer"
+          lazy={false}
+        />
+      );
+
+      expect(container.firstChild).toBeNull();
+
+      mockCanShow = true;
+
+      rerender(
+        <AdSlot
+          placement="search_results_footer"
+          lazy={false}
+        />
+      );
+
+      expect(
+        screen.getByTestId('house-ad')
+      ).toBeInTheDocument();
+
+      mockCanShow = false;
+
+      rerender(
+        <AdSlot
+          placement="search_results_footer"
+          lazy={false}
+        />
+      );
+
+      expect(container.firstChild).toBeNull();
+    }
+  );
+});


### PR DESCRIPTION
Fixes React error #300 when opening search inside a chat.

The conditional AdSlot return previously occurred before two useEffect hooks. When ad eligibility changed, React received a different number of hooks between renders and crashed.

Changes:

- Calls all AdSlot hooks before evaluating whether the slot should render.
- Guards effect behavior using shouldRender.
- Adds a regression test covering hidden → visible → hidden transitions.

Verification:

- AdSlot regression test passed.
- Production Vite build succeeded.