### PR TITLE
Fix/device authority hardening

### DIFF
--- a/server/__tests__/calls.routes.test.js
+++ b/server/__tests__/calls.routes.test.js
@@ -284,7 +284,10 @@ describe('calls routes', () => {
         .send({ callId: 1, answer: { type: 'answer', sdp: 'sdp' } });
 
       expect(res.statusCode).toBe(404);
-      expect(res.body).toEqual({ error: 'Call not found' });
+      expect(res.body).toEqual({
+        error: 'Call not found',
+        code: 'CALL_NOT_FOUND',
+      });
     });
 
     test('403 when caller tries to answer', async () => {
@@ -300,7 +303,10 @@ describe('calls routes', () => {
         .send({ callId: 1, answer: { type: 'answer', sdp: 'sdp' } });
 
       expect(res.statusCode).toBe(403);
-      expect(res.body).toEqual({ error: 'Only callee can answer' });
+      expect(res.body).toEqual({
+        error: 'Only callee can answer',
+        code: 'ONLY_CALLEE_CAN_ANSWER',
+      });
     });
 
     test('409 when status not RINGING or INITIATED', async () => {
@@ -316,7 +322,91 @@ describe('calls routes', () => {
         .send({ callId: 1, answer: { type: 'answer', sdp: 'sdp' } });
 
       expect(res.statusCode).toBe(409);
-      expect(res.body).toEqual({ error: 'Cannot answer in status ENDED' });
+      expect(res.body).toEqual({
+        error: 'Cannot answer in status ENDED',
+        code: 'CALL_NOT_ANSWERABLE',
+        callId: 1,
+        status: 'ENDED',
+      });
+    });
+
+    test('409 CALL_ANSWERED_ELSEWHERE when another device already won the answer race', async () => {
+      const startedAt =
+        new Date('2025-01-02T00:00:00.000Z');
+
+      /*
+       * First lookup is the request's initial RINGING state.
+       * The atomic claim then loses (count: 0), and its authoritative
+       * re-read shows another device already moved the call ACTIVE.
+       */
+      mockPrisma.call.findUnique
+        .mockResolvedValueOnce({
+          id: 1,
+          callerId: 20,
+          calleeId: 10,
+          mode: 'AUDIO',
+          status: 'RINGING',
+        })
+        .mockResolvedValueOnce({
+          id: 1,
+          callerId: 20,
+          calleeId: 10,
+          mode: 'AUDIO',
+          status: 'ACTIVE',
+          startedAt,
+        });
+
+      mockPrisma.call.updateMany.mockResolvedValue({
+        count: 0,
+      });
+
+      const res = await request(app)
+        .post('/calls/answer')
+        .send({
+          callId: 1,
+          answer: {
+            type: 'answer',
+            sdp: 'losing-answer-sdp',
+          },
+        });
+
+      expect(res.statusCode).toBe(409);
+
+      expect(res.body).toEqual({
+        error: 'This call was answered on another device.',
+        code: 'CALL_ANSWERED_ELSEWHERE',
+        callId: 1,
+        status: 'ACTIVE',
+      });
+
+      expect(
+        mockPrisma.call.updateMany
+      ).toHaveBeenCalledWith({
+        where: {
+          id: 1,
+          status: {
+            in: ['RINGING', 'INITIATED'],
+          },
+        },
+        data: {
+          status: 'ACTIVE',
+          answerSdp: 'losing-answer-sdp',
+          startedAt: expect.any(Date),
+          endReason: null,
+        },
+      });
+
+      /*
+       * Losing devices must not become joined participants and must not
+       * emit a second answer event that could disturb the winner.
+       */
+      expect(
+        mockPrisma.callParticipant.updateMany
+      ).not.toHaveBeenCalled();
+
+      expect(
+        emitToUserMock
+      ).not.toHaveBeenCalled();
     });
 
     test('200 on success, emits call:answer to caller', async () => {
@@ -329,14 +419,26 @@ describe('calls routes', () => {
         status: 'RINGING',
       });
 
-      mockPrisma.call.update.mockResolvedValue({
-        id: 1,
-        callerId: 20,
-        calleeId: 10,
-        mode: 'AUDIO',
-        status: 'ACTIVE',
-        startedAt: now,
+      mockPrisma.call.updateMany.mockResolvedValue({
+        count: 1,
       });
+
+      mockPrisma.call.findUnique
+        .mockResolvedValueOnce({
+          id: 1,
+          callerId: 20,
+          calleeId: 10,
+          mode: 'AUDIO',
+          status: 'RINGING',
+        })
+        .mockResolvedValueOnce({
+          id: 1,
+          callerId: 20,
+          calleeId: 10,
+          mode: 'AUDIO',
+          status: 'ACTIVE',
+          startedAt: now,
+        });
 
       mockPrisma.callParticipant.updateMany.mockResolvedValue({
         count: 1,
@@ -349,25 +451,43 @@ describe('calls routes', () => {
         .send({ callId: 1, answer });
 
       expect(res.statusCode).toBe(200);
-      expect(res.body).toEqual({ ok: true });
+      expect(res.body).toEqual({
+        ok: true,
+        callId: 1,
+        status: 'ACTIVE',
+      });
 
-      expect(mockPrisma.call.update).toHaveBeenCalledWith({
-        where: { id: 1 },
+      expect(mockPrisma.call.updateMany).toHaveBeenCalledWith({
+        where: {
+          id: 1,
+          status: {
+            in: ['RINGING', 'INITIATED'],
+          },
+        },
         data: {
           status: 'ACTIVE',
           answerSdp: 'answer-sdp',
           startedAt: expect.any(Date),
           endReason: null,
         },
-        select: {
-          id: true,
-          callerId: true,
-          calleeId: true,
-          mode: true,
-          status: true,
-          startedAt: true,
-        },
       });
+
+      expect(mockPrisma.call.findUnique).toHaveBeenNthCalledWith(
+        2,
+        {
+          where: {
+            id: 1,
+          },
+          select: {
+            id: true,
+            callerId: true,
+            calleeId: true,
+            mode: true,
+            status: true,
+            startedAt: true,
+          },
+        }
+      );
 
       expect(mockPrisma.callParticipant.updateMany).toHaveBeenCalledWith({
         where: {
@@ -635,66 +755,59 @@ describe('calls routes', () => {
   });
 
   describe('PATCH /calls/:id/status', () => {
-    test('a late terminal patch does not overwrite or re-emit the winning terminal state', async () => {
-      const startedAt = new Date('2025-01-05T00:00:00.000Z');
-      const endedAt = new Date('2025-01-05T00:01:00.000Z');
+    test('a stale remote-ended acknowledgement cannot terminate an active call', async () => {
+      const startedAt =
+        new Date('2025-01-05T00:00:00.000Z');
+
+      const activeCall = {
+        id: 1,
+        callerId: 20,
+        calleeId: 10,
+        mode: 'AUDIO',
+        status: 'ACTIVE',
+        startedAt,
+        endedAt: null,
+        durationSec: null,
+        endReason: null,
+        twilioCallSid: null,
+      };
 
       mockPrisma.call.findUnique
         .mockResolvedValueOnce({
-          id: 1,
-          callerId: 20,
-          calleeId: 10,
-          mode: 'VIDEO',
-          status: 'ENDED',
-          participants: [{ userId: 20 }, { userId: 10 }],
+          ...activeCall,
+          participants: [
+            { userId: 20 },
+            { userId: 10 },
+          ],
         })
-        .mockResolvedValueOnce({
-          id: 1,
-          callerId: 20,
-          calleeId: 10,
-          mode: 'VIDEO',
-          status: 'ENDED',
-          startedAt,
-          endedAt,
-          durationSec: 60,
-          endReason: 'hangup',
-          twilioCallSid: null,
-        });
-
-      mockPrisma.call.updateMany.mockResolvedValue({ count: 0 });
+        .mockResolvedValueOnce(activeCall);
 
       const res = await request(app)
         .patch('/calls/1/status')
         .send({
           status: 'ENDED',
-          endedAt: '2025-01-05T00:02:00.000Z',
-          durationSec: 120,
+          endedAt:
+            '2025-01-05T00:00:00.250Z',
+          durationSec: null,
           endReason: 'remote_ended',
         });
 
       expect(res.statusCode).toBe(200);
+
       expect(res.body.call).toMatchObject({
         id: 1,
-        status: 'ENDED',
-        durationSec: 60,
-        endReason: 'hangup',
+        status: 'ACTIVE',
+        endedAt: null,
+        endReason: null,
       });
 
-      expect(mockPrisma.call.updateMany).toHaveBeenCalledWith({
-        where: {
-          id: 1,
-          status: { notIn: ['ENDED', 'DECLINED', 'MISSED', 'FAILED'] },
-        },
-        data: {
-          status: 'ENDED',
-          startedAt: undefined,
-          endedAt: new Date('2025-01-05T00:02:00.000Z'),
-          durationSec: 120,
-          endReason: 'remote_ended',
-        },
-      });
+      expect(
+        mockPrisma.call.updateMany
+      ).not.toHaveBeenCalled();
 
-      expect(emitToUserMock).not.toHaveBeenCalled();
+      expect(
+        emitToUserMock
+      ).not.toHaveBeenCalled();
     });
   });
 });

--- a/server/__tests__/devices.test.js
+++ b/server/__tests__/devices.test.js
@@ -110,6 +110,58 @@ describe('Device registration and replacement', () => {
     expect(prismaMock.device.upsert).toHaveBeenCalledTimes(1);
   });
 
+  test('active device refresh does not rewrite revocation authority', async () => {
+    prismaMock.device.findUnique.mockResolvedValue({
+      revokedAt: null,
+    });
+
+    prismaMock.device.findMany.mockResolvedValue([]);
+
+    prismaMock.device.upsert.mockResolvedValue(
+      makeDevice()
+    );
+
+    const response = await request(app)
+      .post('/devices/register')
+      .send({
+        deviceId: 'device-new',
+        name: 'Android Device',
+        platform: 'Android',
+        publicKey: 'mock-public-key',
+      });
+
+    expect(response.status).toBe(200);
+
+    const upsert =
+      prismaMock.device.upsert.mock.calls[0][0];
+
+    expect(upsert.update).not.toHaveProperty('revokedAt');
+    expect(upsert.update).not.toHaveProperty('revokedById');
+  });
+
+  test('revoked device cannot silently re-register', async () => {
+    prismaMock.device.findUnique.mockResolvedValue({
+      revokedAt: new Date('2026-08-01T20:00:00.000Z'),
+    });
+
+    prismaMock.device.findMany.mockResolvedValue([]);
+
+    const response = await request(app)
+      .post('/devices/register')
+      .send({
+        deviceId: 'device-revoked',
+        name: 'Old Android Device',
+        platform: 'Android',
+        publicKey: 'mock-public-key',
+      });
+
+    expect(response.status).toBe(409);
+    expect(response.body.code).toBe('DEVICE_REVOKED');
+
+    expect(prismaMock.device.upsert).not.toHaveBeenCalled();
+    expect(prismaMock.device.updateMany).not.toHaveBeenCalled();
+  });
+
   test('FREE reinstall requires replacement confirmation', async () => {
     prismaMock.device.findMany.mockResolvedValue([
       {
@@ -271,11 +323,148 @@ describe('Device registration and replacement', () => {
   });
 });
 
+describe('Device pairing authority', () => {
+  let app;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    app = makeApp();
+  });
+
+  test('revoked device cannot resurrect through pairing request', async () => {
+    prismaMock.device.findUnique.mockResolvedValue({
+      revokedAt: new Date('2026-08-01T20:00:00.000Z'),
+    });
+
+    const response = await request(app)
+      .post('/devices/pairing/request')
+      .send({
+        deviceId: 'device-revoked',
+        name: 'Old Android Device',
+        platform: 'Android',
+        publicKey: 'mock-public-key',
+      });
+
+    expect(response.status).toBe(409);
+    expect(response.body.code).toBe('DEVICE_REVOKED');
+
+    expect(prismaMock.device.upsert).not.toHaveBeenCalled();
+  });
+
+  test('active or new device pairing does not rewrite revocation authority', async () => {
+    prismaMock.device.findUnique.mockResolvedValue(null);
+
+    prismaMock.device.upsert.mockResolvedValue(
+      makeDevice({
+        deviceId: 'device-new',
+      })
+    );
+
+    const response = await request(app)
+      .post('/devices/pairing/request')
+      .send({
+        deviceId: 'device-new',
+        name: 'Android Device',
+        platform: 'Android',
+        publicKey: 'mock-public-key',
+      });
+
+    expect(response.status).toBe(200);
+
+    const upsert =
+      prismaMock.device.upsert.mock.calls[0][0];
+
+    expect(upsert.update).not.toHaveProperty('revokedAt');
+    expect(upsert.update).not.toHaveProperty('revokedById');
+  });
+});
+
+describe('Device logout', () => {
+  let app;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    app = makeApp();
+  });
+
+  test('logout clears push credentials without revoking the device', async () => {
+    prismaMock.device.updateMany.mockResolvedValue({
+      count: 1,
+    });
+
+    const response = await request(app)
+      .post('/devices/logout')
+      .send({
+        deviceId: 'device-current',
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body.success).toBe(true);
+    expect(response.body.deviceId).toBe('device-current');
+
+    expect(prismaMock.device.updateMany).toHaveBeenCalledWith({
+      where: {
+        userId: 1,
+        deviceId: 'device-current',
+        revokedAt: null,
+      },
+      data: {
+        pushToken: null,
+        pushProvider: null,
+        apnsPushToken: null,
+        apnsSandboxPushToken: null,
+        fcmPushToken: null,
+        voipPushToken: null,
+        voipSandboxPushToken: null,
+        lastSeenAt: expect.any(Date),
+      },
+    });
+
+    const update =
+      prismaMock.device.updateMany.mock.calls[0][0];
+
+    expect(update.data).not.toHaveProperty('revokedAt');
+    expect(update.data).not.toHaveProperty('revokedById');
+    expect(update.data).not.toHaveProperty('publicKey');
+  });
+
+  test('logout cannot modify a nonexistent or unauthorized device', async () => {
+    prismaMock.device.updateMany.mockResolvedValue({
+      count: 0,
+    });
+
+    const response = await request(app)
+      .post('/devices/logout')
+      .send({
+        deviceId: 'not-my-active-device',
+      });
+
+    expect(response.status).toBe(404);
+    expect(response.body.code).toBe('DEVICE_NOT_FOUND');
+  });
+
+  test('logout requires deviceId', async () => {
+    const response = await request(app)
+      .post('/devices/logout')
+      .send({});
+
+    expect(response.status).toBe(400);
+    expect(response.body.code).toBe('DEVICE_ID_REQUIRED');
+
+    expect(prismaMock.device.updateMany).not.toHaveBeenCalled();
+  });
+});
+
 describe('Push-token registration', () => {
   let app;
 
   beforeEach(() => {
     jest.resetAllMocks();
+
+    prismaMock.$transaction.mockImplementation(
+      async (callback) => callback(prismaMock)
+    );
+
     app = makeApp();
   });
 

--- a/server/__tests__/voiceClient.test.js
+++ b/server/__tests__/voiceClient.test.js
@@ -2,6 +2,8 @@ import request from 'supertest';
 import express from 'express';
 import { jest } from '@jest/globals';
 
+const prismaDeviceFindUnique = jest.fn();
+
 await jest.unstable_mockModule('../middleware/auth.js', () => ({
   __esModule: true,
   requireAuth: (req, res, next) => {
@@ -10,6 +12,15 @@ await jest.unstable_mockModule('../middleware/auth.js', () => ({
     }
 
     return next();
+  },
+}));
+
+await jest.unstable_mockModule('../utils/prismaClient.js', () => ({
+  __esModule: true,
+  default: {
+    device: {
+      findUnique: prismaDeviceFindUnique,
+    },
   },
 }));
 
@@ -58,6 +69,7 @@ describe('POST /voice/token', () => {
 
   beforeEach(() => {
     process.env = { ...OLD_ENV };
+    prismaDeviceFindUnique.mockReset();
   });
 
   afterAll(() => {
@@ -118,21 +130,186 @@ describe('POST /voice/token', () => {
     expect(res.body.error).toMatch(/unauthorized/i);
   });
 
-  test('returns 200 and a Twilio Access Token when env vars and user are present', async () => {
-    const app = buildAppWithUser({ id: 42 });
+  test('keeps legacy user identity when mobile client omits deviceId', async () => {
+  const app = buildAppWithUser({ id: 42 });
 
-    process.env.TWILIO_ACCOUNT_SID = 'AC_test_sid';
-    process.env.TWILIO_API_KEY_SID = 'SK_test_key';
-    process.env.TWILIO_API_KEY_SECRET = 'supersecret';
-    process.env.TWILIO_VOICE_TWIML_APP_SID = 'AP_test_app';
+  process.env.TWILIO_ACCOUNT_SID = 'AC_test_sid';
+  process.env.TWILIO_API_KEY_SID = 'SK_test_key';
+  process.env.TWILIO_API_KEY_SECRET = 'supersecret';
+  process.env.TWILIO_VOICE_TWIML_APP_SID = 'AP_test_app';
+  process.env.TWILIO_ANDROID_PUSH_CREDENTIAL_SID = 'CR_android_push';
 
-    const res = await request(app).post('/voice/token');
-
-    expect(res.status).toBe(200);
-    expect(res.body).toEqual({
-      token: 'mock-jwt-for-user_42',
-      identity: 'user_42',
-      ttlSeconds: 60 * 60,
+  const res = await request(app)
+    .post('/voice/token')
+    .send({
+      platform: 'android',
     });
+
+  expect(res.status).toBe(200);
+  expect(res.body).toEqual({
+    token: 'mock-jwt-for-user_42',
+    identity: 'user_42',
+    ttlSeconds: 60 * 60,
+    deviceSpecific: false,
+  });
+
+  expect(prismaDeviceFindUnique).not.toHaveBeenCalled();
+  });
+
+  test('returns device-specific identity for registered Android device', async () => {
+  prismaDeviceFindUnique.mockResolvedValue({
+    deviceId: 'android-device-123',
+    platform: 'android',
+    revokedAt: null,
+    pairingStatus: 'approved',
+  });
+
+  const app = buildAppWithUser({ id: 42 });
+
+  process.env.TWILIO_ACCOUNT_SID = 'AC_test_sid';
+  process.env.TWILIO_API_KEY_SID = 'SK_test_key';
+  process.env.TWILIO_API_KEY_SECRET = 'supersecret';
+  process.env.TWILIO_VOICE_TWIML_APP_SID = 'AP_test_app';
+  process.env.TWILIO_ANDROID_PUSH_CREDENTIAL_SID = 'CR_android_push';
+
+  const res = await request(app)
+    .post('/voice/token')
+    .send({
+      platform: 'android',
+      deviceId: 'android-device-123',
+    });
+
+  expect(res.status).toBe(200);
+
+  expect(prismaDeviceFindUnique).toHaveBeenCalledWith({
+    where: {
+      userId_deviceId: {
+        userId: 42,
+        deviceId: 'android-device-123',
+      },
+    },
+    select: {
+      deviceId: true,
+      platform: true,
+      revokedAt: true,
+      pairingStatus: true,
+    },
+  });
+
+  expect(res.body).toEqual({
+    token: 'mock-jwt-for-user_42_device_android_device_123',
+    identity: 'user_42_device_android_device_123',
+    ttlSeconds: 60 * 60,
+    deviceSpecific: true,
+  });
+  });
+
+  test('returns device-specific identity for registered iOS device', async () => {
+  prismaDeviceFindUnique.mockResolvedValue({
+    deviceId: 'ios-device-456',
+    platform: 'ios',
+    revokedAt: null,
+    pairingStatus: 'approved',
+  });
+
+  const app = buildAppWithUser({ id: 42 });
+
+  process.env.TWILIO_ACCOUNT_SID = 'AC_test_sid';
+  process.env.TWILIO_API_KEY_SID = 'SK_test_key';
+  process.env.TWILIO_API_KEY_SECRET = 'supersecret';
+  process.env.TWILIO_VOICE_TWIML_APP_SID = 'AP_test_app';
+  process.env.TWILIO_IOS_PUSH_CREDENTIAL_SID = 'CR_ios_prod_push';
+
+  const res = await request(app)
+    .post('/voice/token')
+    .send({
+      platform: 'ios',
+      pushEnvironment: 'production',
+      deviceId: 'ios-device-456',
+    });
+
+  expect(res.status).toBe(200);
+
+  expect(res.body).toEqual({
+    token: 'mock-jwt-for-user_42_device_ios_device_456',
+    identity: 'user_42_device_ios_device_456',
+    ttlSeconds: 60 * 60,
+    deviceSpecific: true,
+  });
+  });
+
+  test('rejects unknown mobile device', async () => {
+  prismaDeviceFindUnique.mockResolvedValue(null);
+
+  const app = buildAppWithUser({ id: 42 });
+
+  process.env.TWILIO_ACCOUNT_SID = 'AC_test_sid';
+  process.env.TWILIO_API_KEY_SID = 'SK_test_key';
+  process.env.TWILIO_API_KEY_SECRET = 'supersecret';
+  process.env.TWILIO_VOICE_TWIML_APP_SID = 'AP_test_app';
+
+  const res = await request(app)
+    .post('/voice/token')
+    .send({
+      platform: 'android',
+      deviceId: 'missing-device',
+    });
+
+  expect(res.status).toBe(409);
+  expect(res.body.code).toBe(
+    'DEVICE_REGISTRATION_REQUIRED'
+  );
+  });
+
+  test('rejects revoked mobile device', async () => {
+  prismaDeviceFindUnique.mockResolvedValue({
+    deviceId: 'revoked-device',
+    platform: 'android',
+    revokedAt: new Date('2026-08-01T00:00:00Z'),
+    pairingStatus: 'approved',
+  });
+
+  const app = buildAppWithUser({ id: 42 });
+
+  process.env.TWILIO_ACCOUNT_SID = 'AC_test_sid';
+  process.env.TWILIO_API_KEY_SID = 'SK_test_key';
+  process.env.TWILIO_API_KEY_SECRET = 'supersecret';
+  process.env.TWILIO_VOICE_TWIML_APP_SID = 'AP_test_app';
+
+  const res = await request(app)
+    .post('/voice/token')
+    .send({
+      platform: 'android',
+      deviceId: 'revoked-device',
+    });
+
+  expect(res.status).toBe(409);
+  expect(res.body.code).toBe('DEVICE_REVOKED');
+  });
+
+  test('rejects rejected mobile device', async () => {
+  prismaDeviceFindUnique.mockResolvedValue({
+    deviceId: 'rejected-device',
+    platform: 'ios',
+    revokedAt: null,
+    pairingStatus: 'rejected',
+  });
+
+  const app = buildAppWithUser({ id: 42 });
+
+  process.env.TWILIO_ACCOUNT_SID = 'AC_test_sid';
+  process.env.TWILIO_API_KEY_SID = 'SK_test_key';
+  process.env.TWILIO_API_KEY_SECRET = 'supersecret';
+  process.env.TWILIO_VOICE_TWIML_APP_SID = 'AP_test_app';
+
+  const res = await request(app)
+    .post('/voice/token')
+    .send({
+      platform: 'ios',
+      deviceId: 'rejected-device',
+    });
+
+  expect(res.status).toBe(409);
+  expect(res.body.code).toBe('DEVICE_NOT_APPROVED');
   });
 });

--- a/server/routes/calls.js
+++ b/server/routes/calls.js
@@ -803,6 +803,51 @@ router.patch('/:id/status', asyncHandler(async (req, res) => {
   const normalizedStatus =
     status == null ? null : String(status).toUpperCase();
 
+  const normalizedEndReason =
+    endReason == null
+      ? null
+      : String(endReason).trim().toLowerCase();
+
+  // A remote-ended report is local cleanup after another lifecycle event.
+  // It must not become the authoritative terminal transition. Otherwise a
+  // stale same-account client can end the call immediately after another
+  // device successfully claims it ACTIVE.
+  if (
+    isTerminalCallStatus(normalizedStatus) &&
+    normalizedEndReason === 'remote_ended'
+  ) {
+    console.log(
+      '[calls/status] ignored non-authoritative remote-ended acknowledgement',
+      {
+        callId,
+        reportedBy: userId,
+        authoritativeStatus: call.status,
+      }
+    );
+
+    const authoritative = await prisma.call.findUnique({
+      where: {
+        id: callId,
+      },
+      select: {
+        id: true,
+        callerId: true,
+        calleeId: true,
+        mode: true,
+        status: true,
+        startedAt: true,
+        endedAt: true,
+        durationSec: true,
+        endReason: true,
+        twilioCallSid: true,
+      },
+    });
+
+    return res.json({
+      call: authoritative,
+    });
+  }
+
   const updateData = {
     status: normalizedStatus ?? undefined,
     startedAt:

--- a/server/routes/devices.js
+++ b/server/routes/devices.js
@@ -198,6 +198,24 @@ router.post('/register', requireAuth, async (req, res, next) => {
         Boolean(currentDevice) &&
         currentDevice.revokedAt == null;
 
+      /*
+       * Revocation is authoritative.
+       *
+       * A client that retains an old JWT, socket session, push token,
+       * or local deviceId must not be able to resurrect a revoked
+       * installation simply by calling /devices/register again.
+       */
+      if (currentDevice?.revokedAt) {
+        return {
+          status: 409,
+          body: {
+            error:
+              'This device has been revoked and cannot register again.',
+            code: 'DEVICE_REVOKED',
+          },
+        };
+      }
+
       const activeOtherDevices = await tx.device.findMany({
         where: {
           userId,
@@ -325,8 +343,6 @@ router.post('/register', requireAuth, async (req, res, next) => {
             ? keyVersion
             : 1,
           lastSeenAt: new Date(),
-          revokedAt: null,
-          revokedById: null,
           pairingStatus: 'approved',
           pairingApprovedAt: new Date(),
           pairingRejectedAt: null,
@@ -405,6 +421,26 @@ router.post('/pairing/request', requireAuth, async (req, res, next) => {
       return res.status(400).json({ error: 'deviceId and publicKey are required' });
     }
 
+    const existingDevice = await prisma.device.findUnique({
+      where: {
+        userId_deviceId: {
+          userId,
+          deviceId,
+        },
+      },
+      select: {
+        revokedAt: true,
+      },
+    });
+
+    if (existingDevice?.revokedAt) {
+      return res.status(409).json({
+        error:
+          'This device has been revoked and cannot request pairing.',
+        code: 'DEVICE_REVOKED',
+      });
+    }
+
     const device = await prisma.device.upsert({
       where: {
         userId_deviceId: {
@@ -419,7 +455,6 @@ router.post('/pairing/request', requireAuth, async (req, res, next) => {
         keyAlgorithm,
         keyVersion: Number.isFinite(keyVersion) ? keyVersion : 1,
         lastSeenAt: new Date(),
-        revokedAt: null,
         wrappedAccountKey: null,
         wrappedAccountKeyAlgo: null,
         wrappedAccountKeyVer: null,
@@ -744,6 +779,61 @@ router.post('/heartbeat', requireAuth, async (req, res, next) => {
     next(error);
   }
 });
+
+router.post('/logout', requireAuth, async (req, res, next) => {
+  try {
+    const userId = Number(req.user.id);
+    const deviceId =
+      normalizeString(req.body?.deviceId, 191);
+
+    if (!userId || !deviceId) {
+      return res.status(400).json({
+        error: 'deviceId is required',
+        code: 'DEVICE_ID_REQUIRED',
+      });
+    }
+
+    /*
+     * Logout is not revocation.
+     *
+     * Keep the device identity, encryption metadata, and pairing state.
+     * Remove delivery credentials so a signed-out installation cannot
+     * continue receiving messages or incoming-call pushes.
+     */
+    const result = await prisma.device.updateMany({
+      where: {
+        userId,
+        deviceId,
+        revokedAt: null,
+      },
+      data: {
+        pushToken: null,
+        pushProvider: null,
+        apnsPushToken: null,
+        apnsSandboxPushToken: null,
+        fcmPushToken: null,
+        voipPushToken: null,
+        voipSandboxPushToken: null,
+        lastSeenAt: new Date(),
+      },
+    });
+
+    if (result.count < 1) {
+      return res.status(404).json({
+        error: 'Active device not found',
+        code: 'DEVICE_NOT_FOUND',
+      });
+    }
+
+    return res.json({
+      success: true,
+      deviceId,
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
 
 router.post('/revoke', requireAuth, async (req, res, next) => {
   try {

--- a/server/routes/voiceClient.js
+++ b/server/routes/voiceClient.js
@@ -1,6 +1,7 @@
 import express from 'express';
 import twilio from 'twilio';
 import { requireAuth } from '../middleware/auth.js';
+import prisma from '../utils/prismaClient.js';
 
 const router = express.Router();
 
@@ -8,12 +9,29 @@ const { jwt } = twilio;
 const { AccessToken } = jwt;
 const { VoiceGrant } = AccessToken;
 
+function normalizeVoiceIdentityPart(value) {
+  return String(value || '')
+    .trim()
+    .replace(/[^A-Za-z0-9_]/g, '_');
+}
+
+export function buildDeviceVoiceIdentity(userId, deviceId) {
+  const safeDeviceId = normalizeVoiceIdentityPart(deviceId);
+
+  if (!safeDeviceId) {
+    return null;
+  }
+
+  return `user_${Number(userId)}_device_${safeDeviceId}`;
+}
+
+
 /**
  * POST /voice/client/token
  *
  * Returns a Twilio Voice Access Token for Chatforia clients.
  */
-router.post('/token', requireAuth, (req, res) => {
+router.post('/token', requireAuth, async (req, res) => {
   try {
     const accountSid = process.env.TWILIO_ACCOUNT_SID;
     const apiKeySid = process.env.TWILIO_API_KEY_SID;
@@ -26,18 +44,14 @@ router.post('/token', requireAuth, (req, res) => {
       });
     }
 
-    const userId = req.user?.id;
-    if (!userId) {
+    const userId = Number(req.user?.id);
+
+    if (!Number.isInteger(userId) || userId <= 0) {
       return res.status(401).json({ error: 'Unauthorized' });
     }
 
-    const identity = `user_${userId}`;
+    let identity = `user_${userId}`;
     const ttlSeconds = 60 * 60;
-
-    const token = new AccessToken(accountSid, apiKeySid, apiKeySecret, {
-      identity,
-      ttl: ttlSeconds,
-    });
 
     const androidPushCredentialSid =
       process.env.TWILIO_ANDROID_PUSH_CREDENTIAL_SID;
@@ -70,6 +84,68 @@ router.post('/token', requireAuth, (req, res) => {
       platform.includes('ipad') ||
       platform.includes('cfnetwork') ||
       platform.includes('darwin');
+
+    const requestedDeviceId = String(
+      req.body?.deviceId ||
+        req.query?.deviceId ||
+        ''
+    ).trim();
+
+    const isMobile = isAndroid || isIOS;
+
+    if (isMobile && requestedDeviceId) {
+      const verifiedDevice = await prisma.device.findUnique({
+        where: {
+          userId_deviceId: {
+            userId,
+            deviceId: requestedDeviceId,
+          },
+        },
+        select: {
+          deviceId: true,
+          platform: true,
+          revokedAt: true,
+          pairingStatus: true,
+        },
+      });
+
+      if (!verifiedDevice) {
+        return res.status(409).json({
+          error:
+            'Device must be registered before requesting a Voice token.',
+          code: 'DEVICE_REGISTRATION_REQUIRED',
+        });
+      }
+
+      if (verifiedDevice.revokedAt) {
+        return res.status(409).json({
+          error: 'This device has been revoked.',
+          code: 'DEVICE_REVOKED',
+        });
+      }
+
+      if (verifiedDevice.pairingStatus === 'rejected') {
+        return res.status(409).json({
+          error: 'This device is not approved.',
+          code: 'DEVICE_NOT_APPROVED',
+        });
+      }
+
+      identity = buildDeviceVoiceIdentity(
+        userId,
+        requestedDeviceId
+      );
+    }
+
+    const token = new AccessToken(
+      accountSid,
+      apiKeySid,
+      apiKeySecret,
+      {
+        identity,
+        ttl: ttlSeconds,
+      }
+    );
 
     const iosPushEnvironment =
       requestedPushEnvironment || 'production';
@@ -125,6 +201,11 @@ router.post('/token', requireAuth, (req, res) => {
       platform,
       isAndroid,
       isIOS,
+      deviceSpecific: Boolean(isMobile && requestedDeviceId),
+      deviceIdSuffix:
+        requestedDeviceId
+          ? requestedDeviceId.slice(-8)
+          : null,
       pushEnvironment:
         isIOS ? iosPushEnvironment : null,
       hasAndroidPushCredentialSid:
@@ -144,6 +225,7 @@ router.post('/token', requireAuth, (req, res) => {
       token: token.toJwt(),
       identity,
       ttlSeconds,
+      deviceSpecific: Boolean(isMobile && requestedDeviceId),
     });
   } catch (err) {
     console.error('[voiceClient] token error', err);


### PR DESCRIPTION
Summary

This PR hardens call/device authority behavior and adds the first stage of device-specific Twilio Voice identity support.

Included
Hardened call arbitration and device authority behavior.
Preserved canonical call state during simultaneous-call races.
Hardened device registration/replacement/logout behavior.
Added device-specific Twilio Voice identities for registered Android and iOS devices.
Preserved legacy user_<id> Voice identities for older mobile clients that do not yet send a deviceId.
Rejects unknown, revoked, or rejected devices when requesting a device-specific Voice token.
Validation
Focused Voice token Jest suite: 8/8 passing
node --check passes for the modified Voice route and test file.
git diff --check passes.
Migration note

This is a backwards-compatible migration stage. Incoming Twilio Voice <Dial> routing has not yet been changed to device-specific fanout.

After this backend change is deployed, updated Android and iOS clients will be run so they can register Twilio Voice push bindings under their device-specific identities. Device-specific incoming-call fanout will be implemented only after those registrations are verified in production.