### PR TITLE
Add authoritative device Voice registration

### DIFF
--- a/server/__tests__/voiceClient.test.js
+++ b/server/__tests__/voiceClient.test.js
@@ -3,6 +3,7 @@ import express from 'express';
 import { jest } from '@jest/globals';
 
 const prismaDeviceFindUnique = jest.fn();
+const prismaDeviceUpdate = jest.fn();
 
 await jest.unstable_mockModule('../middleware/auth.js', () => ({
   __esModule: true,
@@ -20,6 +21,7 @@ await jest.unstable_mockModule('../utils/prismaClient.js', () => ({
   default: {
     device: {
       findUnique: prismaDeviceFindUnique,
+      update: prismaDeviceUpdate,
     },
   },
 }));
@@ -70,6 +72,7 @@ describe('POST /voice/token', () => {
   beforeEach(() => {
     process.env = { ...OLD_ENV };
     prismaDeviceFindUnique.mockReset();
+    prismaDeviceUpdate.mockReset();
   });
 
   afterAll(() => {
@@ -312,4 +315,284 @@ describe('POST /voice/token', () => {
   expect(res.status).toBe(409);
   expect(res.body.code).toBe('DEVICE_NOT_APPROVED');
   });
+
+  test('confirms successful Android Voice registration', async () => {
+    prismaDeviceFindUnique.mockResolvedValue({
+      deviceId: 'android-device-123',
+      platform: 'android',
+      revokedAt: null,
+      pairingStatus: 'approved',
+    });
+
+    prismaDeviceUpdate.mockResolvedValue({});
+
+    const app = buildAppWithUser({ id: 42 });
+
+    const res = await request(app)
+      .post('/voice/registration')
+      .send({
+        deviceId: 'android-device-123',
+      });
+
+    expect(res.status).toBe(200);
+
+    expect(res.body).toEqual({
+      ok: true,
+      identity: 'user_42_device_android_device_123',
+      registrationVersion: 1,
+      pushEnvironment: null,
+    });
+
+    expect(prismaDeviceFindUnique).toHaveBeenCalledWith({
+      where: {
+        userId_deviceId: {
+          userId: 42,
+          deviceId: 'android-device-123',
+        },
+      },
+      select: {
+        deviceId: true,
+        platform: true,
+        revokedAt: true,
+        pairingStatus: true,
+      },
+    });
+
+    expect(prismaDeviceUpdate).toHaveBeenCalledWith({
+      where: {
+        userId_deviceId: {
+          userId: 42,
+          deviceId: 'android-device-123',
+        },
+      },
+      data: {
+        voiceIdentity:
+          'user_42_device_android_device_123',
+        voiceRegisteredAt: expect.any(Date),
+        voiceRegistrationVer: 1,
+        voicePushEnvironment: null,
+      },
+    });
+  });
+
+  test('confirms successful production iOS Voice registration', async () => {
+    prismaDeviceFindUnique.mockResolvedValue({
+      deviceId: 'ios-device-456',
+      platform: 'ios',
+      revokedAt: null,
+      pairingStatus: 'approved',
+    });
+
+    prismaDeviceUpdate.mockResolvedValue({});
+
+    const app = buildAppWithUser({ id: 42 });
+
+    const res = await request(app)
+      .post('/voice/registration')
+      .send({
+        deviceId: 'ios-device-456',
+        pushEnvironment: 'production',
+      });
+
+    expect(res.status).toBe(200);
+
+    expect(res.body).toEqual({
+      ok: true,
+      identity: 'user_42_device_ios_device_456',
+      registrationVersion: 1,
+      pushEnvironment: 'production',
+    });
+
+    expect(prismaDeviceUpdate).toHaveBeenCalledWith({
+      where: {
+        userId_deviceId: {
+          userId: 42,
+          deviceId: 'ios-device-456',
+        },
+      },
+      data: {
+        voiceIdentity:
+          'user_42_device_ios_device_456',
+        voiceRegisteredAt: expect.any(Date),
+        voiceRegistrationVer: 1,
+        voicePushEnvironment: 'production',
+      },
+    });
+  });
+
+  test('confirms successful sandbox iOS Voice registration', async () => {
+    prismaDeviceFindUnique.mockResolvedValue({
+      deviceId: 'ios-device-789',
+      platform: 'ios',
+      revokedAt: null,
+      pairingStatus: 'approved',
+    });
+
+    prismaDeviceUpdate.mockResolvedValue({});
+
+    const app = buildAppWithUser({ id: 42 });
+
+    const res = await request(app)
+      .post('/voice/registration')
+      .send({
+        deviceId: 'ios-device-789',
+        pushEnvironment: 'sandbox',
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.pushEnvironment).toBe('sandbox');
+
+    expect(prismaDeviceUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          voicePushEnvironment: 'sandbox',
+          voiceRegistrationVer: 1,
+        }),
+      })
+    );
+  });
+
+  test('rejects Voice registration when deviceId is missing', async () => {
+    const app = buildAppWithUser({ id: 42 });
+
+    const res = await request(app)
+      .post('/voice/registration')
+      .send({});
+
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('DEVICE_ID_REQUIRED');
+    expect(prismaDeviceFindUnique).not.toHaveBeenCalled();
+    expect(prismaDeviceUpdate).not.toHaveBeenCalled();
+  });
+
+  test('rejects Voice registration for unknown device', async () => {
+    prismaDeviceFindUnique.mockResolvedValue(null);
+
+    const app = buildAppWithUser({ id: 42 });
+
+    const res = await request(app)
+      .post('/voice/registration')
+      .send({
+        deviceId: 'missing-device',
+      });
+
+    expect(res.status).toBe(409);
+    expect(res.body.code).toBe(
+      'DEVICE_REGISTRATION_REQUIRED'
+    );
+    expect(prismaDeviceUpdate).not.toHaveBeenCalled();
+  });
+
+  test('rejects Voice registration for revoked device', async () => {
+    prismaDeviceFindUnique.mockResolvedValue({
+      deviceId: 'revoked-device',
+      platform: 'android',
+      revokedAt: new Date(),
+      pairingStatus: 'approved',
+    });
+
+    const app = buildAppWithUser({ id: 42 });
+
+    const res = await request(app)
+      .post('/voice/registration')
+      .send({
+        deviceId: 'revoked-device',
+      });
+
+    expect(res.status).toBe(409);
+    expect(res.body.code).toBe('DEVICE_REVOKED');
+    expect(prismaDeviceUpdate).not.toHaveBeenCalled();
+  });
+
+  test('rejects Voice registration for rejected device', async () => {
+    prismaDeviceFindUnique.mockResolvedValue({
+      deviceId: 'rejected-device',
+      platform: 'android',
+      revokedAt: null,
+      pairingStatus: 'rejected',
+    });
+
+    const app = buildAppWithUser({ id: 42 });
+
+    const res = await request(app)
+      .post('/voice/registration')
+      .send({
+        deviceId: 'rejected-device',
+      });
+
+    expect(res.status).toBe(409);
+    expect(res.body.code).toBe('DEVICE_NOT_APPROVED');
+    expect(prismaDeviceUpdate).not.toHaveBeenCalled();
+  });
+
+  test('rejects Voice registration for unsupported device platform', async () => {
+    prismaDeviceFindUnique.mockResolvedValue({
+      deviceId: 'web-device',
+      platform: 'web',
+      revokedAt: null,
+      pairingStatus: 'approved',
+    });
+
+    const app = buildAppWithUser({ id: 42 });
+
+    const res = await request(app)
+      .post('/voice/registration')
+      .send({
+        deviceId: 'web-device',
+      });
+
+    expect(res.status).toBe(409);
+    expect(res.body.code).toBe(
+      'VOICE_PLATFORM_UNSUPPORTED'
+    );
+    expect(prismaDeviceUpdate).not.toHaveBeenCalled();
+  });
+
+  test('rejects iOS Voice registration without push environment', async () => {
+    prismaDeviceFindUnique.mockResolvedValue({
+      deviceId: 'ios-device',
+      platform: 'ios',
+      revokedAt: null,
+      pairingStatus: 'approved',
+    });
+
+    const app = buildAppWithUser({ id: 42 });
+
+    const res = await request(app)
+      .post('/voice/registration')
+      .send({
+        deviceId: 'ios-device',
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe(
+      'INVALID_IOS_PUSH_ENVIRONMENT'
+    );
+    expect(prismaDeviceUpdate).not.toHaveBeenCalled();
+  });
+
+  test('rejects invalid iOS Voice push environment', async () => {
+    prismaDeviceFindUnique.mockResolvedValue({
+      deviceId: 'ios-device',
+      platform: 'ios',
+      revokedAt: null,
+      pairingStatus: 'approved',
+    });
+
+    const app = buildAppWithUser({ id: 42 });
+
+    const res = await request(app)
+      .post('/voice/registration')
+      .send({
+        deviceId: 'ios-device',
+        pushEnvironment: 'invalid',
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe(
+      'INVALID_IOS_PUSH_ENVIRONMENT'
+    );
+    expect(prismaDeviceUpdate).not.toHaveBeenCalled();
+  });
+
 });

--- a/server/__tests__/voiceDeviceService.test.js
+++ b/server/__tests__/voiceDeviceService.test.js
@@ -1,0 +1,240 @@
+import { jest } from '@jest/globals';
+
+const prismaDeviceFindMany = jest.fn();
+
+await jest.unstable_mockModule(
+  '../utils/prismaClient.js',
+  () => ({
+    __esModule: true,
+    default: {
+      device: {
+        findMany: prismaDeviceFindMany,
+      },
+    },
+  })
+);
+
+const {
+  getVoiceEligibleDevices,
+  getVoiceDialDestinations,
+  isVoiceEligibleDevice,
+} = await import(
+  '../services/voiceDeviceService.js'
+);
+
+describe('voiceDeviceService', () => {
+  beforeEach(() => {
+    prismaDeviceFindMany.mockReset();
+  });
+
+  function registeredAndroid(overrides = {}) {
+    return {
+      deviceId: 'android-device-123',
+      platform: 'android',
+      pairingStatus: 'approved',
+      revokedAt: null,
+      isPrimary: false,
+      lastSeenAt: new Date(),
+      updatedAt: new Date(),
+      voiceIdentity:
+        'user_42_device_android_device_123',
+      voiceRegisteredAt: new Date(),
+      voiceRegistrationVer: 1,
+      voicePushEnvironment: null,
+      ...overrides,
+    };
+  }
+
+  function registeredIOS(overrides = {}) {
+    return {
+      deviceId: 'ios-device-456',
+      platform: 'ios',
+      pairingStatus: 'approved',
+      revokedAt: null,
+      isPrimary: false,
+      lastSeenAt: new Date(),
+      updatedAt: new Date(),
+      voiceIdentity:
+        'user_42_device_ios_device_456',
+      voiceRegisteredAt: new Date(),
+      voiceRegistrationVer: 1,
+      voicePushEnvironment: 'production',
+      ...overrides,
+    };
+  }
+
+  test('accepts a valid confirmed Android Voice registration', () => {
+    expect(
+      isVoiceEligibleDevice(
+        registeredAndroid(),
+        42
+      )
+    ).toBe(true);
+  });
+
+  test('accepts a valid confirmed iOS Voice registration', () => {
+    expect(
+      isVoiceEligibleDevice(
+        registeredIOS(),
+        42
+      )
+    ).toBe(true);
+  });
+
+  test('rejects a revoked device', () => {
+    expect(
+      isVoiceEligibleDevice(
+        registeredAndroid({
+          revokedAt: new Date(),
+        }),
+        42
+      )
+    ).toBe(false);
+  });
+
+  test('rejects a rejected device', () => {
+    expect(
+      isVoiceEligibleDevice(
+        registeredAndroid({
+          pairingStatus: 'rejected',
+        }),
+        42
+      )
+    ).toBe(false);
+  });
+
+  test('rejects device without confirmed registration timestamp', () => {
+    expect(
+      isVoiceEligibleDevice(
+        registeredAndroid({
+          voiceRegisteredAt: null,
+        }),
+        42
+      )
+    ).toBe(false);
+  });
+
+  test('rejects stale registration version', () => {
+    expect(
+      isVoiceEligibleDevice(
+        registeredAndroid({
+          voiceRegistrationVer: 0,
+        }),
+        42
+      )
+    ).toBe(false);
+  });
+
+  test('rejects stored identity that does not match derived identity', () => {
+    expect(
+      isVoiceEligibleDevice(
+        registeredAndroid({
+          voiceIdentity:
+            'user_999_device_android_device_123',
+        }),
+        42
+      )
+    ).toBe(false);
+  });
+
+  test('rejects iOS registration without valid push environment', () => {
+    expect(
+      isVoiceEligibleDevice(
+        registeredIOS({
+          voicePushEnvironment: null,
+        }),
+        42
+      )
+    ).toBe(false);
+  });
+
+  test('returns multiple independently registered mobile devices', async () => {
+    prismaDeviceFindMany.mockResolvedValue([
+      registeredAndroid(),
+      registeredIOS(),
+    ]);
+
+    const devices =
+      await getVoiceEligibleDevices(42);
+
+    expect(devices).toHaveLength(2);
+    expect(devices.map((d) => d.deviceId)).toEqual([
+      'android-device-123',
+      'ios-device-456',
+    ]);
+  });
+
+  test('returns device-specific dial destinations for registered devices', async () => {
+    prismaDeviceFindMany.mockResolvedValue([
+      registeredAndroid(),
+      registeredIOS(),
+    ]);
+
+    const destinations =
+      await getVoiceDialDestinations(42);
+
+    expect(destinations).toEqual([
+      {
+        identity:
+          'user_42_device_android_device_123',
+        deviceId: 'android-device-123',
+        platform: 'android',
+        legacy: false,
+      },
+      {
+        identity:
+          'user_42_device_ios_device_456',
+        deviceId: 'ios-device-456',
+        platform: 'ios',
+        legacy: false,
+      },
+    ]);
+  });
+
+  test('uses temporary legacy fallback when no confirmed device exists', async () => {
+    prismaDeviceFindMany.mockResolvedValue([]);
+
+    const destinations =
+      await getVoiceDialDestinations(42);
+
+    expect(destinations).toEqual([
+      {
+        identity: 'user_42',
+        deviceId: null,
+        platform: null,
+        legacy: true,
+      },
+    ]);
+  });
+
+  test('can disable legacy fallback for final production migration state', async () => {
+    prismaDeviceFindMany.mockResolvedValue([]);
+
+    const destinations =
+      await getVoiceDialDestinations(
+        42,
+        {
+          allowLegacyFallback: false,
+        }
+      );
+
+    expect(destinations).toEqual([]);
+  });
+
+  test('never returns more than 10 eligible devices', async () => {
+    prismaDeviceFindMany.mockResolvedValue(
+      Array.from({ length: 15 }, (_, index) =>
+        registeredAndroid({
+          deviceId: `device-${index}`,
+          voiceIdentity:
+            `user_42_device_device_${index}`,
+        })
+      )
+    );
+
+    const devices =
+      await getVoiceEligibleDevices(42);
+
+    expect(devices).toHaveLength(10);
+  });
+});

--- a/server/prisma/migrations/20260614000000_add_message_payloads/migration.sql
+++ b/server/prisma/migrations/20260614000000_add_message_payloads/migration.sql
@@ -1,0 +1,24 @@
+-- CreateTable
+CREATE TABLE "MessagePayload" (
+    "messageId" INTEGER NOT NULL,
+    "userId" INTEGER NOT NULL,
+    "contentCiphertext" JSONB NOT NULL,
+    "encryptedKey" TEXT NOT NULL,
+    "language" TEXT,
+    "sourceLanguage" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "MessagePayload_pkey" PRIMARY KEY ("messageId","userId")
+);
+
+-- CreateIndex
+CREATE INDEX "MessagePayload_messageId_idx" ON "MessagePayload"("messageId");
+
+-- CreateIndex
+CREATE INDEX "MessagePayload_userId_idx" ON "MessagePayload"("userId");
+
+-- AddForeignKey
+ALTER TABLE "MessagePayload" ADD CONSTRAINT "MessagePayload_messageId_fkey" FOREIGN KEY ("messageId") REFERENCES "Message"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "MessagePayload" ADD CONSTRAINT "MessagePayload_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/server/prisma/migrations/20260712050000_repair_support_automation_tables/migration.sql
+++ b/server/prisma/migrations/20260712050000_repair_support_automation_tables/migration.sql
@@ -1,0 +1,45 @@
+-- Repair tables skipped when
+-- 20260508220249_add_stripe_webhook_events failed before
+-- reaching its CREATE TABLE statements and was subsequently
+-- recorded as applied.
+
+CREATE TABLE IF NOT EXISTS "SupportAutomationEvent" (
+    "id" SERIAL NOT NULL,
+    "userId" INTEGER,
+    "ticketId" INTEGER,
+    "category" TEXT NOT NULL,
+    "source" TEXT NOT NULL DEFAULT 'support',
+    "status" TEXT NOT NULL DEFAULT 'detected',
+    "actionTaken" TEXT,
+    "metadata" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "SupportAutomationEvent_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE IF NOT EXISTS "SupportAutoAction" (
+    "id" SERIAL NOT NULL,
+    "userId" INTEGER,
+    "category" TEXT NOT NULL,
+    "action" TEXT NOT NULL,
+    "status" TEXT NOT NULL,
+    "metadata" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "SupportAutoAction_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX IF NOT EXISTS "SupportAutomationEvent_userId_idx"
+ON "SupportAutomationEvent"("userId");
+
+CREATE INDEX IF NOT EXISTS "SupportAutomationEvent_category_idx"
+ON "SupportAutomationEvent"("category");
+
+CREATE INDEX IF NOT EXISTS "SupportAutomationEvent_createdAt_idx"
+ON "SupportAutomationEvent"("createdAt");
+
+CREATE INDEX IF NOT EXISTS "SupportAutoAction_userId_idx"
+ON "SupportAutoAction"("userId");
+
+CREATE INDEX IF NOT EXISTS "SupportAutoAction_category_idx"
+ON "SupportAutoAction"("category");

--- a/server/prisma/migrations/20260712053000_enforce_phone_number_inventory_flags_not_null/migration.sql
+++ b/server/prisma/migrations/20260712053000_enforce_phone_number_inventory_flags_not_null/migration.sql
@@ -1,0 +1,7 @@
+-- Align the production PhoneNumber table with the Prisma schema.
+-- Existing defaults already match the schema, and all existing rows
+-- were verified to contain non-null values.
+
+ALTER TABLE "PhoneNumber"
+ALTER COLUMN "isLeasable" SET NOT NULL,
+ALTER COLUMN "isPurchasable" SET NOT NULL;

--- a/server/prisma/migrations/20260726034500_add_wireless_refund_audit/migration.sql
+++ b/server/prisma/migrations/20260726034500_add_wireless_refund_audit/migration.sql
@@ -1,0 +1,16 @@
+ALTER TABLE "MobileDataPackPurchase"
+ADD COLUMN "stripeChargeId" TEXT,
+ADD COLUMN "refundStatus" TEXT,
+ADD COLUMN "refundedAmountMinor" INTEGER NOT NULL DEFAULT 0,
+ADD COLUMN "refundedCurrency" TEXT,
+ADD COLUMN "refundedDataMb" INTEGER NOT NULL DEFAULT 0,
+ADD COLUMN "lastRefundId" TEXT,
+ADD COLUMN "lastRefundEventId" TEXT,
+ADD COLUMN "refundedAt" TIMESTAMP(3),
+ADD COLUMN "refundReviewRequired" BOOLEAN NOT NULL DEFAULT false;
+
+CREATE INDEX "MobileDataPackPurchase_refundReviewRequired_idx"
+ON "MobileDataPackPurchase"("refundReviewRequired");
+
+CREATE INDEX "MobileDataPackPurchase_refundStatus_idx"
+ON "MobileDataPackPurchase"("refundStatus");

--- a/server/prisma/migrations/20260810040300_add_device_voice_registration_authority/migration.sql
+++ b/server/prisma/migrations/20260810040300_add_device_voice_registration_authority/migration.sql
@@ -1,0 +1,8 @@
+ALTER TABLE "Device"
+ADD COLUMN "voiceIdentity" TEXT,
+ADD COLUMN "voiceRegisteredAt" TIMESTAMP(3),
+ADD COLUMN "voiceRegistrationVer" INTEGER NOT NULL DEFAULT 0,
+ADD COLUMN "voicePushEnvironment" TEXT;
+
+CREATE UNIQUE INDEX "Device_voiceIdentity_key"
+ON "Device"("voiceIdentity");

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -483,6 +483,14 @@ model Device {
   voipPushToken        String? @unique
   voipSandboxPushToken String? @unique
 
+  // Twilio Voice device-addressable registration authority.
+  // A push token alone does not prove that a Twilio Voice identity
+  // has successfully registered on this physical device.
+  voiceIdentity        String?   @unique
+  voiceRegisteredAt    DateTime?
+  voiceRegistrationVer Int       @default(0)
+  voicePushEnvironment String?
+
   wrappedAccountKey     String?
   wrappedAccountKeyAlgo String?
   wrappedAccountKeyVer  Int?

--- a/server/routes/voiceClient.js
+++ b/server/routes/voiceClient.js
@@ -2,29 +2,16 @@ import express from 'express';
 import twilio from 'twilio';
 import { requireAuth } from '../middleware/auth.js';
 import prisma from '../utils/prismaClient.js';
+import {
+  buildDeviceVoiceIdentity,
+  VOICE_REGISTRATION_VERSION,
+} from '../utils/voiceIdentity.js';
 
 const router = express.Router();
 
 const { jwt } = twilio;
 const { AccessToken } = jwt;
 const { VoiceGrant } = AccessToken;
-
-function normalizeVoiceIdentityPart(value) {
-  return String(value || '')
-    .trim()
-    .replace(/[^A-Za-z0-9_]/g, '_');
-}
-
-export function buildDeviceVoiceIdentity(userId, deviceId) {
-  const safeDeviceId = normalizeVoiceIdentityPart(deviceId);
-
-  if (!safeDeviceId) {
-    return null;
-  }
-
-  return `user_${Number(userId)}_device_${safeDeviceId}`;
-}
-
 
 /**
  * POST /voice/client/token
@@ -231,6 +218,166 @@ router.post('/token', requireAuth, async (req, res) => {
     console.error('[voiceClient] token error', err);
     return res.status(500).json({
       error: 'Failed to create voice token',
+    });
+  }
+});
+
+
+/**
+ * POST /voice/client/registration
+ *
+ * Records a successful device-specific Twilio Voice registration.
+ * The backend derives the Voice identity and never trusts a
+ * client-supplied identity.
+ */
+router.post('/registration', requireAuth, async (req, res) => {
+  try {
+    const userId = Number(req.user?.id);
+    const deviceId = String(req.body?.deviceId || '').trim();
+
+    if (!Number.isInteger(userId) || userId <= 0) {
+      return res.status(401).json({ error: 'Unauthorized' });
+    }
+
+    if (!deviceId) {
+      return res.status(400).json({
+        error: 'deviceId is required',
+        code: 'DEVICE_ID_REQUIRED',
+      });
+    }
+
+    const device = await prisma.device.findUnique({
+      where: {
+        userId_deviceId: {
+          userId,
+          deviceId,
+        },
+      },
+      select: {
+        deviceId: true,
+        platform: true,
+        revokedAt: true,
+        pairingStatus: true,
+      },
+    });
+
+    if (!device) {
+      return res.status(409).json({
+        error:
+          'Device must be registered before confirming Voice registration.',
+        code: 'DEVICE_REGISTRATION_REQUIRED',
+      });
+    }
+
+    if (device.revokedAt) {
+      return res.status(409).json({
+        error: 'This device has been revoked.',
+        code: 'DEVICE_REVOKED',
+      });
+    }
+
+    if (
+      String(device.pairingStatus || '')
+        .trim()
+        .toLowerCase() === 'rejected'
+    ) {
+      return res.status(409).json({
+        error: 'This device is not approved.',
+        code: 'DEVICE_NOT_APPROVED',
+      });
+    }
+
+    const platform = String(device.platform || '')
+      .trim()
+      .toLowerCase();
+
+    if (platform !== 'android' && platform !== 'ios') {
+      return res.status(409).json({
+        error: 'This device platform does not support Twilio Voice.',
+        code: 'VOICE_PLATFORM_UNSUPPORTED',
+      });
+    }
+
+    let voicePushEnvironment = null;
+
+    if (platform === 'ios') {
+      voicePushEnvironment = String(
+        req.body?.pushEnvironment || ''
+      )
+        .trim()
+        .toLowerCase();
+
+      if (
+        voicePushEnvironment !== 'production' &&
+        voicePushEnvironment !== 'sandbox'
+      ) {
+        return res.status(400).json({
+          error:
+            'iOS Voice registration requires pushEnvironment production or sandbox.',
+          code: 'INVALID_IOS_PUSH_ENVIRONMENT',
+        });
+      }
+    }
+
+    const voiceIdentity = buildDeviceVoiceIdentity(
+      userId,
+      device.deviceId
+    );
+
+    if (!voiceIdentity) {
+      return res.status(500).json({
+        error: 'Unable to derive Voice identity.',
+        code: 'VOICE_IDENTITY_INVALID',
+      });
+    }
+
+    const registeredAt = new Date();
+
+    await prisma.device.update({
+      where: {
+        userId_deviceId: {
+          userId,
+          deviceId,
+        },
+      },
+      data: {
+        voiceIdentity,
+        voiceRegisteredAt: registeredAt,
+        voiceRegistrationVer:
+          VOICE_REGISTRATION_VERSION,
+        voicePushEnvironment,
+      },
+    });
+
+    console.log(
+      '[voiceClient] device Voice registration confirmed',
+      {
+        userId,
+        deviceIdSuffix: deviceId.slice(-8),
+        identity: voiceIdentity,
+        platform,
+        voiceRegistrationVer:
+          VOICE_REGISTRATION_VERSION,
+        voicePushEnvironment,
+      }
+    );
+
+    return res.status(200).json({
+      ok: true,
+      identity: voiceIdentity,
+      registrationVersion:
+        VOICE_REGISTRATION_VERSION,
+      pushEnvironment: voicePushEnvironment,
+    });
+  } catch (error) {
+    console.error(
+      '[voiceClient] Voice registration confirmation failed',
+      error
+    );
+
+    return res.status(500).json({
+      error: 'Failed to confirm Voice registration.',
+      code: 'VOICE_REGISTRATION_CONFIRMATION_FAILED',
     });
   }
 });

--- a/server/services/voiceDeviceService.js
+++ b/server/services/voiceDeviceService.js
@@ -1,0 +1,196 @@
+import prisma from '../utils/prismaClient.js';
+import {
+  buildDeviceVoiceIdentity,
+  buildLegacyVoiceIdentity,
+  MAX_VOICE_FANOUT_DEVICES,
+  VOICE_REGISTRATION_VERSION,
+} from '../utils/voiceIdentity.js';
+
+function normalizePlatform(platform) {
+  return String(platform || '').trim().toLowerCase();
+}
+
+export function isVoiceEligibleDevice(device, userId) {
+  if (!device) return false;
+
+  const numericUserId = Number(userId);
+
+  if (!Number.isInteger(numericUserId) || numericUserId <= 0) {
+    return false;
+  }
+
+  if (device.revokedAt) {
+    return false;
+  }
+
+  if (
+    String(device.pairingStatus || '')
+      .trim()
+      .toLowerCase() === 'rejected'
+  ) {
+    return false;
+  }
+
+  const platform = normalizePlatform(device.platform);
+
+  if (platform !== 'android' && platform !== 'ios') {
+    return false;
+  }
+
+  if (!String(device.deviceId || '').trim()) {
+    return false;
+  }
+
+  if (!device.voiceRegisteredAt) {
+    return false;
+  }
+
+  if (
+    Number(device.voiceRegistrationVer) !==
+    VOICE_REGISTRATION_VERSION
+  ) {
+    return false;
+  }
+
+  const expectedIdentity = buildDeviceVoiceIdentity(
+    numericUserId,
+    device.deviceId
+  );
+
+  if (
+    !expectedIdentity ||
+    device.voiceIdentity !== expectedIdentity
+  ) {
+    return false;
+  }
+
+  if (platform === 'ios') {
+    const environment = String(
+      device.voicePushEnvironment || ''
+    )
+      .trim()
+      .toLowerCase();
+
+    if (
+      environment !== 'production' &&
+      environment !== 'sandbox'
+    ) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+export async function getVoiceEligibleDevices(
+  userId,
+  {
+    limit = MAX_VOICE_FANOUT_DEVICES,
+  } = {}
+) {
+  const numericUserId = Number(userId);
+
+  if (!Number.isInteger(numericUserId) || numericUserId <= 0) {
+    return [];
+  }
+
+  const safeLimit = Math.min(
+    MAX_VOICE_FANOUT_DEVICES,
+    Math.max(
+      1,
+      Number(limit) || MAX_VOICE_FANOUT_DEVICES
+    )
+  );
+
+  const candidates = await prisma.device.findMany({
+    where: {
+      userId: numericUserId,
+      revokedAt: null,
+      voiceRegisteredAt: {
+        not: null,
+      },
+      voiceRegistrationVer:
+        VOICE_REGISTRATION_VERSION,
+      voiceIdentity: {
+        not: null,
+      },
+    },
+    select: {
+      deviceId: true,
+      platform: true,
+      pairingStatus: true,
+      revokedAt: true,
+      isPrimary: true,
+      lastSeenAt: true,
+      updatedAt: true,
+      voiceIdentity: true,
+      voiceRegisteredAt: true,
+      voiceRegistrationVer: true,
+      voicePushEnvironment: true,
+    },
+    orderBy: [
+      { isPrimary: 'desc' },
+      { lastSeenAt: 'desc' },
+      { updatedAt: 'desc' },
+    ],
+    take: MAX_VOICE_FANOUT_DEVICES * 3,
+  });
+
+  return candidates
+    .filter((device) =>
+      isVoiceEligibleDevice(device, numericUserId)
+    )
+    .slice(0, safeLimit);
+}
+
+export async function getVoiceDialDestinations(
+  userId,
+  {
+    allowLegacyFallback = true,
+  } = {}
+) {
+  const numericUserId = Number(userId);
+
+  const devices = await getVoiceEligibleDevices(
+    numericUserId
+  );
+
+  const deviceDestinations = devices
+    .map((device) => ({
+      identity: device.voiceIdentity,
+      deviceId: device.deviceId,
+      platform: normalizePlatform(device.platform),
+      legacy: false,
+    }))
+    .filter((destination) =>
+      Boolean(destination.identity)
+    );
+
+  if (deviceDestinations.length > 0) {
+    return deviceDestinations;
+  }
+
+  /*
+   * Temporary migration compatibility only.
+   *
+   * Remove this fallback after supported Android/iOS versions
+   * reliably confirm device-specific Voice registration.
+   */
+  if (!allowLegacyFallback) {
+    return [];
+  }
+
+  const legacyIdentity =
+    buildLegacyVoiceIdentity(numericUserId);
+
+  return legacyIdentity
+    ? [
+        {
+          identity: legacyIdentity,
+          deviceId: null,
+          platform: null,
+          legacy: true,
+        },
+      ]
+    : [];
+}

--- a/server/utils/voiceIdentity.js
+++ b/server/utils/voiceIdentity.js
@@ -1,0 +1,64 @@
+export const MAX_VOICE_FANOUT_DEVICES = 10;
+export const VOICE_REGISTRATION_VERSION = 1;
+
+export function normalizeVoiceIdentityPart(value) {
+  return String(value || '')
+    .trim()
+    .replace(/[^A-Za-z0-9_]/g, '_');
+}
+
+export function buildDeviceVoiceIdentity(userId, deviceId) {
+  const numericUserId = Number(userId);
+  const safeDeviceId = normalizeVoiceIdentityPart(deviceId);
+
+  if (
+    !Number.isInteger(numericUserId) ||
+    numericUserId <= 0 ||
+    !safeDeviceId
+  ) {
+    return null;
+  }
+
+  return `user_${numericUserId}_device_${safeDeviceId}`;
+}
+
+export function buildLegacyVoiceIdentity(userId) {
+  const numericUserId = Number(userId);
+
+  if (!Number.isInteger(numericUserId) || numericUserId <= 0) {
+    return null;
+  }
+
+  return `user_${numericUserId}`;
+}
+
+export function parseVoiceIdentity(identity) {
+  const raw = String(identity || '')
+    .trim()
+    .replace(/^client:/, '');
+
+  const match = raw.match(
+    /^user_(\d+)(?:_device_(.+))?$/
+  );
+
+  if (!match) {
+    return null;
+  }
+
+  const userId = Number(match[1]);
+
+  if (!Number.isInteger(userId) || userId <= 0) {
+    return null;
+  }
+
+  return {
+    identity: raw,
+    userId,
+    deviceSpecific: Boolean(match[2]),
+    deviceIdentityPart: match[2] || null,
+  };
+}
+
+export function parseVoiceIdentityUserId(identity) {
+  return parseVoiceIdentity(identity)?.userId ?? null;
+}


### PR DESCRIPTION
## Summary

Adds the backend authority layer for device-specific Twilio Voice registration and restores missing Prisma migration history so production and source control stay aligned.

## What changed

- Adds device-specific Twilio Voice identity helpers and registration versioning.
- Adds `POST /voice/client/registration` for server-authoritative confirmation after a mobile client successfully registers with Twilio Voice.
- Verifies the authenticated user owns the device and rejects unknown, revoked, rejected, or unsupported devices.
- Stores `voiceIdentity`, `voiceRegisteredAt`, `voiceRegistrationVer`, and `voicePushEnvironment` on `Device`.
- Adds `voiceDeviceService` to determine Voice eligibility from confirmed registration state rather than FCM/APNs token presence.
- Enforces a maximum Voice fanout size of 10 devices and retains temporary legacy identity fallback for migration compatibility.
- Adds focused tests for Android/iOS registration confirmation, invalid/revoked/rejected devices, stale registrations, identity consistency, multi-device eligibility, fallback behavior, and the 10-device cap.
- Restores missing migration directories and adds the new Voice registration authority migration.

## Validation

- `voiceClient.test.js`: 18/18 passing
- `voiceDeviceService.test.js`: 13/13 passing
- Combined focused run: 31/31 passing
- `node --check` passes for the modified/new Voice backend files
- `git diff --check` passes

## Rollout note

This PR intentionally does **not** switch `/webhooks/voice/client` to multi-device fanout yet. The rollout order is:

1. Deploy the registration authority endpoint.
2. Update Android to confirm successful Twilio Voice registration.
3. Verify the Android `Device` row in production.
4. Update iOS to confirm successful Twilio Voice registration.
5. Verify the iOS `Device` row in production.
6. Then enable device-specific multi-client fanout in the Voice webhook.

This avoids routing only a subset of devices during the migration window.