### PR TITLE
Normalize versioned mobile Voice platforms

### DIFF
--- a/server/__tests__/voiceClient.test.js
+++ b/server/__tests__/voiceClient.test.js
@@ -420,6 +420,51 @@ describe('POST /voice/token', () => {
     });
   });
 
+  test('confirms Voice registration for versioned iOS platform', async () => {
+    prismaDeviceFindUnique.mockResolvedValue({
+      deviceId: 'ios-versioned-device',
+      platform: 'iOS 26.6',
+      revokedAt: null,
+      pairingStatus: 'approved',
+    });
+
+    prismaDeviceUpdate.mockResolvedValue({});
+
+    const app = buildAppWithUser({ id: 42 });
+
+    const res = await request(app)
+      .post('/voice/registration')
+      .send({
+        deviceId: 'ios-versioned-device',
+        pushEnvironment: 'sandbox',
+      });
+
+    expect(res.status).toBe(200);
+
+    expect(res.body).toEqual({
+      ok: true,
+      identity: 'user_42_device_ios_versioned_device',
+      registrationVersion: 1,
+      pushEnvironment: 'sandbox',
+    });
+
+    expect(prismaDeviceUpdate).toHaveBeenCalledWith({
+      where: {
+        userId_deviceId: {
+          userId: 42,
+          deviceId: 'ios-versioned-device',
+        },
+      },
+      data: {
+        voiceIdentity:
+          'user_42_device_ios_versioned_device',
+        voiceRegisteredAt: expect.any(Date),
+        voiceRegistrationVer: 1,
+        voicePushEnvironment: 'sandbox',
+      },
+    });
+  });
+
   test('confirms successful sandbox iOS Voice registration', async () => {
     prismaDeviceFindUnique.mockResolvedValue({
       deviceId: 'ios-device-789',

--- a/server/__tests__/voiceDeviceService.test.js
+++ b/server/__tests__/voiceDeviceService.test.js
@@ -81,6 +81,26 @@ describe('voiceDeviceService', () => {
     ).toBe(true);
   });
 
+  test('accepts versioned iOS platform strings', () => {
+    expect(
+      isVoiceEligibleDevice(
+        registeredIOS({
+          platform: 'iOS 26.6',
+        }),
+        42
+      )
+    ).toBe(true);
+
+    expect(
+      isVoiceEligibleDevice(
+        registeredIOS({
+          platform: 'iOS 26.5.2',
+        }),
+        42
+      )
+    ).toBe(true);
+  });
+
   test('rejects a revoked device', () => {
     expect(
       isVoiceEligibleDevice(

--- a/server/routes/voiceClient.js
+++ b/server/routes/voiceClient.js
@@ -5,6 +5,7 @@ import prisma from '../utils/prismaClient.js';
 import {
   buildDeviceVoiceIdentity,
   VOICE_REGISTRATION_VERSION,
+  normalizeVoicePlatform,
 } from '../utils/voiceIdentity.js';
 
 const router = express.Router();
@@ -287,11 +288,11 @@ router.post('/registration', requireAuth, async (req, res) => {
       });
     }
 
-    const platform = String(device.platform || '')
-      .trim()
-      .toLowerCase();
+    const platform = normalizeVoicePlatform(
+      device.platform
+    );
 
-    if (platform !== 'android' && platform !== 'ios') {
+    if (!platform) {
       return res.status(409).json({
         error: 'This device platform does not support Twilio Voice.',
         code: 'VOICE_PLATFORM_UNSUPPORTED',

--- a/server/services/voiceDeviceService.js
+++ b/server/services/voiceDeviceService.js
@@ -4,11 +4,8 @@ import {
   buildLegacyVoiceIdentity,
   MAX_VOICE_FANOUT_DEVICES,
   VOICE_REGISTRATION_VERSION,
+  normalizeVoicePlatform,
 } from '../utils/voiceIdentity.js';
-
-function normalizePlatform(platform) {
-  return String(platform || '').trim().toLowerCase();
-}
 
 export function isVoiceEligibleDevice(device, userId) {
   if (!device) return false;
@@ -31,9 +28,9 @@ export function isVoiceEligibleDevice(device, userId) {
     return false;
   }
 
-  const platform = normalizePlatform(device.platform);
+  const platform = normalizeVoicePlatform(device.platform);
 
-  if (platform !== 'android' && platform !== 'ios') {
+  if (!platform) {
     return false;
   }
 
@@ -159,7 +156,7 @@ export async function getVoiceDialDestinations(
     .map((device) => ({
       identity: device.voiceIdentity,
       deviceId: device.deviceId,
-      platform: normalizePlatform(device.platform),
+      platform: normalizeVoicePlatform(device.platform),
       legacy: false,
     }))
     .filter((destination) =>

--- a/server/utils/voiceIdentity.js
+++ b/server/utils/voiceIdentity.js
@@ -1,6 +1,32 @@
 export const MAX_VOICE_FANOUT_DEVICES = 10;
 export const VOICE_REGISTRATION_VERSION = 1;
 
+export function normalizeVoicePlatform(value) {
+  const platform = String(value || '')
+    .trim()
+    .toLowerCase();
+
+  if (!platform) {
+    return null;
+  }
+
+  if (platform.includes('android')) {
+    return 'android';
+  }
+
+  if (
+    platform.includes('ios') ||
+    platform.includes('iphone') ||
+    platform.includes('ipad') ||
+    platform.includes('cfnetwork') ||
+    platform.includes('darwin')
+  ) {
+    return 'ios';
+  }
+
+  return null;
+}
+
 export function normalizeVoiceIdentityPart(value) {
   return String(value || '')
     .trim()


### PR DESCRIPTION
Normalizes stored mobile platform values such as iOS 26.6 for authoritative Twilio Voice registration and device eligibility. Adds regression coverage for versioned iOS platform strings.

This is the clean replacement for PR #82, based directly on current main and containing only the platform-normalization fix.