### PR TITLE
Protect active calls from losing device failures

### DIFF
--- a/server/__tests__/calls.routes.test.js
+++ b/server/__tests__/calls.routes.test.js
@@ -809,5 +809,60 @@ describe('calls routes', () => {
         emitToUserMock
       ).not.toHaveBeenCalled();
     });
+
+    test('a losing callee device cannot fail an already active multi-device call', async () => {
+      const startedAt =
+        new Date('2026-08-10T20:21:48.527Z');
+
+      const activeCall = {
+        id: 703,
+        callerId: 20,
+        calleeId: 10,
+        mode: 'AUDIO',
+        status: 'ACTIVE',
+        startedAt,
+        endedAt: null,
+        durationSec: null,
+        endReason: null,
+        twilioCallSid: null,
+      };
+
+      mockPrisma.call.findUnique
+        .mockResolvedValueOnce({
+          ...activeCall,
+          participants: [
+            { userId: 20 },
+            { userId: 10 },
+          ],
+        })
+        .mockResolvedValueOnce(activeCall);
+
+      const res = await request(app)
+        .patch('/calls/703/status')
+        .send({
+          status: 'FAILED',
+          endedAt:
+            '2026-08-10T20:22:05.000Z',
+          endReason:
+            'No incoming call to answer.',
+        });
+
+      expect(res.statusCode).toBe(200);
+
+      expect(res.body.call).toMatchObject({
+        id: 703,
+        status: 'ACTIVE',
+        endedAt: null,
+        endReason: null,
+      });
+
+      expect(
+        mockPrisma.call.updateMany
+      ).not.toHaveBeenCalled();
+
+      expect(
+        emitToUserMock
+      ).not.toHaveBeenCalled();
+    });
   });
 });

--- a/server/routes/calls.js
+++ b/server/routes/calls.js
@@ -808,20 +808,38 @@ router.patch('/:id/status', asyncHandler(async (req, res) => {
       ? null
       : String(endReason).trim().toLowerCase();
 
-  // A remote-ended report is local cleanup after another lifecycle event.
-  // It must not become the authoritative terminal transition. Otherwise a
-  // stale same-account client can end the call immediately after another
-  // device successfully claims it ACTIVE.
-  if (
+  const isRemoteEndedAcknowledgement =
     isTerminalCallStatus(normalizedStatus) &&
-    normalizedEndReason === 'remote_ended'
+    normalizedEndReason === 'remote_ended';
+
+  const isActiveCalleeLosingLegFailure =
+    call.status === 'ACTIVE' &&
+    userId === call.calleeId &&
+    normalizedStatus === 'FAILED' &&
+    normalizedEndReason === 'no incoming call to answer.';
+
+  // These reports describe local device cleanup rather than an authoritative
+  // account-level terminal transition.
+  //
+  // In a multi-device call, one callee device can successfully answer while
+  // another device loses its local Twilio incoming leg. That losing device
+  // must not be allowed to terminate the already-ACTIVE canonical call.
+  if (
+    isRemoteEndedAcknowledgement ||
+    isActiveCalleeLosingLegFailure
   ) {
     console.log(
-      '[calls/status] ignored non-authoritative remote-ended acknowledgement',
+      '[calls/status] ignored non-authoritative device lifecycle acknowledgement',
       {
         callId,
         reportedBy: userId,
+        reportedStatus: normalizedStatus,
+        reportedEndReason: normalizedEndReason,
         authoritativeStatus: call.status,
+        reason:
+          isActiveCalleeLosingLegFailure
+            ? 'losing_device_leg'
+            : 'remote_ended',
       }
     );
 


### PR DESCRIPTION
Prevents a losing callee device from terminating an already-active multi-device call when its local incoming Twilio leg disappears. Preserves the canonical ACTIVE call and adds regression coverage for the production failure observed on call 703.