### PR TITLE
Restrict audio VoIP pushes to eligible Voice devices

### DIFF
--- a/server/services/__tests__/pushService.test.js
+++ b/server/services/__tests__/pushService.test.js
@@ -46,6 +46,8 @@ const getFirebaseMessagingMock = jest.fn();
 const resolveMessageNotificationSoundMock =
   jest.fn(() => 'Chatforia_Default.caf');
 
+const getVoiceEligibleDevicesMock = jest.fn();
+
 await jest.unstable_mockModule('apn', () => ({
   __esModule: true,
   default: {
@@ -77,6 +79,15 @@ await jest.unstable_mockModule(
     __esModule: true,
     resolveMessageNotificationSound:
       resolveMessageNotificationSoundMock,
+  })
+);
+
+await jest.unstable_mockModule(
+  '../services/voiceDeviceService.js',
+  () => ({
+    __esModule: true,
+    getVoiceEligibleDevices:
+      getVoiceEligibleDevicesMock,
   })
 );
 
@@ -139,6 +150,31 @@ describe('pushService APNs environment routing', () => {
       messageTone: 'Default.mp3',
       plan: 'FREE',
     });
+
+    getVoiceEligibleDevicesMock.mockResolvedValue([
+      {
+        deviceId: 'ios-production-device',
+        platform: 'iOS 26.6',
+        voiceIdentity:
+          'user_7_device_ios_production_device',
+        voiceRegisteredAt: new Date(),
+        voiceRegistrationVer: 1,
+        voicePushEnvironment: 'production',
+        voipPushToken: productionVoipToken,
+        voipSandboxPushToken: null,
+      },
+      {
+        deviceId: 'ios-sandbox-device',
+        platform: 'iOS 26.6',
+        voiceIdentity:
+          'user_7_device_ios_sandbox_device',
+        voiceRegisteredAt: new Date(),
+        voiceRegistrationVer: 1,
+        voicePushEnvironment: 'sandbox',
+        voipPushToken: null,
+        voipSandboxPushToken: sandboxVoipToken,
+      },
+    ]);
 
     getFirebaseMessagingMock.mockReturnValue(null);
 
@@ -221,6 +257,89 @@ describe('pushService APNs environment routing', () => {
       expect(result).toMatchObject({
         ok: true,
         apnsVoipSent: 2,
+        apnsVoipFailed: 0,
+      });
+    }
+  );
+
+  it(
+    'does not send AUDIO VoIP pushes to stale non-Voice-registered iOS devices',
+    async () => {
+      const staleProductionToken =
+        'stale-production-voip-token';
+
+      /*
+       * This represents the historical account-level token set:
+       * it contains a stale production iPhone token in addition
+       * to the current sandbox Voice-registered iPhone.
+       *
+       * AUDIO routing must ignore this generic token list and use
+       * getVoiceEligibleDevices() instead.
+       */
+      mockPrisma.device.findMany.mockResolvedValue([
+        {
+          pushToken: null,
+          pushProvider: null,
+          apnsPushToken: null,
+          apnsSandboxPushToken: null,
+          fcmPushToken: null,
+          voipPushToken:
+            staleProductionToken,
+          voipSandboxPushToken: null,
+        },
+      ]);
+
+      getVoiceEligibleDevicesMock.mockResolvedValue([
+        {
+          deviceId: 'current-ios-device',
+          platform: 'iOS 26.6',
+          voiceIdentity:
+            'user_7_device_current_ios_device',
+          voiceRegisteredAt: new Date(),
+          voiceRegistrationVer: 1,
+          voicePushEnvironment: 'sandbox',
+          voipPushToken: null,
+          voipSandboxPushToken:
+            sandboxVoipToken,
+        },
+      ]);
+
+      const result =
+        await sendVoipCallPushToUser(7, {
+          callId: 704,
+          callerId: 1,
+          callerName: 'Caller',
+          mode: 'AUDIO',
+        });
+
+      expect(
+        getVoiceEligibleDevicesMock
+      ).toHaveBeenCalledWith(7);
+
+      expect(providerSendMock)
+        .toHaveBeenCalledTimes(1);
+
+      expect(providerSendMock)
+        .toHaveBeenCalledWith(
+          expect.objectContaining({
+            production: false,
+            tokens: [sandboxVoipToken],
+          })
+        );
+
+      expect(providerSendMock)
+        .not.toHaveBeenCalledWith(
+          expect.objectContaining({
+            tokens:
+              expect.arrayContaining([
+                staleProductionToken,
+              ]),
+          })
+        );
+
+      expect(result).toMatchObject({
+        ok: true,
+        apnsVoipSent: 1,
         apnsVoipFailed: 0,
       });
     }

--- a/server/services/pushService.js
+++ b/server/services/pushService.js
@@ -2,6 +2,7 @@ import apn from 'apn';
 import prisma from '../utils/prismaClient.js';
 import { getFirebaseMessaging } from './firebaseAdmin.js';
 import { resolveMessageNotificationSound } from '../config/messageToneCatalog.js';
+import { getVoiceEligibleDevices } from './voiceDeviceService.js';
 
 const providers = {
   production: null,
@@ -262,18 +263,82 @@ export async function sendVoipCallPushToUser(
   userId,
   payload
 ) {
-  const tokens = await getUserTokens(userId);
+  const isAudioCall =
+    String(payload?.mode || '')
+      .trim()
+      .toUpperCase() === 'AUDIO';
 
-  const groups = [
-    {
-      environment: 'production',
-      tokens: tokens.apnsVoipProduction,
-    },
-    {
-      environment: 'sandbox',
-      tokens: tokens.apnsVoipSandbox,
-    },
-  ];
+  let groups;
+
+  if (isAudioCall) {
+    /*
+     * App-to-app AUDIO calls use authoritative device-specific
+     * Twilio Voice registration. The CallKit VoIP push must target
+     * those same eligible iOS devices rather than every historical
+     * non-revoked VoIP token on the account.
+     */
+    const voiceDevices =
+      await getVoiceEligibleDevices(userId);
+
+    const productionTokens =
+      voiceDevices
+        .filter(
+          (device) =>
+            device.voicePushEnvironment ===
+              'production' &&
+            Boolean(device.voipPushToken)
+        )
+        .map(
+          (device) => device.voipPushToken
+        );
+
+    const sandboxTokens =
+      voiceDevices
+        .filter(
+          (device) =>
+            device.voicePushEnvironment ===
+              'sandbox' &&
+            Boolean(device.voipSandboxPushToken)
+        )
+        .map(
+          (device) =>
+            device.voipSandboxPushToken
+        );
+
+    groups = [
+      {
+        environment: 'production',
+        tokens: [
+          ...new Set(productionTokens),
+        ],
+      },
+      {
+        environment: 'sandbox',
+        tokens: [
+          ...new Set(sandboxTokens),
+        ],
+      },
+    ];
+  } else {
+    /*
+     * Preserve existing behavior for VIDEO and any other current
+     * VoIP-push consumers. This migration is specifically for the
+     * Twilio Voice AUDIO path.
+     */
+    const tokens =
+      await getUserTokens(userId);
+
+    groups = [
+      {
+        environment: 'production',
+        tokens: tokens.apnsVoipProduction,
+      },
+      {
+        environment: 'sandbox',
+        tokens: tokens.apnsVoipSandbox,
+      },
+    ];
+  }
 
   const tokenCount =
     groups.reduce(

--- a/server/services/voiceDeviceService.js
+++ b/server/services/voiceDeviceService.js
@@ -124,6 +124,8 @@ export async function getVoiceEligibleDevices(
       voiceRegisteredAt: true,
       voiceRegistrationVer: true,
       voicePushEnvironment: true,
+      voipPushToken: true,
+      voipSandboxPushToken: true,
     },
     orderBy: [
       { isPrimary: 'desc' },


### PR DESCRIPTION
Restricts app-to-app AUDIO VoIP/CallKit pushes to the same authoritative device-specific Voice registrations used for Twilio fanout.

This prevents stale, non-Voice-registered iOS devices from receiving incoming-call VoIP pushes and later reporting terminal lifecycle states that can incorrectly end the canonical active call.

Includes regression coverage proving stale account-level VoIP tokens are excluded while preserving existing VIDEO push behavior.