### PR TITLE
Clear web call overlay when Twilio call ends

### DIFF
--- a/client/src/context/CallContext.jsx
+++ b/client/src/context/CallContext.jsx
@@ -75,6 +75,14 @@ const twilioVideoRoomRef = useRef(null);
 
     if (
       twilioVoice.callStatus ===
+      'ended'
+    ) {
+      cleanup();
+      return;
+    }
+
+    if (
+      twilioVoice.callStatus ===
       'error'
     ) {
       setPending(false);


### PR DESCRIPTION
Clears the web call UI when the browser Twilio Voice hook reaches its terminal `ended` state. This prevents the site from remaining stuck on an "In call" overlay after the remote/mobile side hangs up.

The change is limited to `client/src/context/CallContext.jsx`. Full client test run had 120/121 suites passing; the only two failures were unrelated ChatView tests caused by `useCall()` returning null in their test harness.