### PR TITLE
Use authoritative web socket for call lifecycle

### DIFF
--- a/client/src/context/CallContext.jsx
+++ b/client/src/context/CallContext.jsx
@@ -1,5 +1,5 @@
 import { createContext, useContext, useEffect, useRef, useState } from 'react';
-import socket from '@/lib/socket';
+import { useSocketRaw } from '@/context/SocketContext';
 import { API_BASE } from '@/config';
 import { useTwilioVoice } from '@/hooks/useTwilioVoice';
 import { joinRoom } from '@/video/video';
@@ -24,6 +24,7 @@ export const useCall = () => useContext(CallCtx);
  * - call:ended    {}
  */
 export function CallProvider({ children, me }) {
+  const socket = useSocketRaw();
   const twilioVoice = useTwilioVoice();
   const [incoming, setIncoming] = useState(null);    // { callId, fromUser, mode, offer }
   const [active, setActive] = useState(null);        // { callId, peerId?, phoneNumber? }
@@ -104,6 +105,8 @@ const twilioVideoRoomRef = useRef(null);
 
   // socket listeners
   useEffect(() => {
+  if (!socket) return undefined;
+
   function normalizeIncoming(payload, fallbackMode = 'AUDIO') {
     const callerId = payload?.callerId ?? payload?.fromUser?.id ?? null;
 
@@ -231,7 +234,7 @@ const twilioVideoRoomRef = useRef(null);
     socket.off('call:participant-offer-needed', onParticipantOfferNeeded);
     socket.off('call:participant-offer', onParticipantOffer);
   };
-}, []);
+}, [socket]);
 
   async function createPeer(nextActive = null) {
     const peerUserId = nextActive?.peerId;

--- a/client/src/context/__tests__/CallContext.test.js
+++ b/client/src/context/__tests__/CallContext.test.js
@@ -222,9 +222,9 @@ const socketMock = {
   },
 };
 
-jest.mock('@/lib/socket', () => ({
+jest.mock('@/context/SocketContext', () => ({
   __esModule: true,
-  default: socketMock,
+  useSocketRaw: () => socketMock,
 }));
 
 jest.mock('@/config', () => ({
@@ -661,6 +661,40 @@ ctxRef.remoteStream.current.getTracks()
 expect(
 ctxRef.localStream.current
 ).toBe(null);
+});
+
+
+test('outgoing audio call cleans up immediately when callee declines', async () => {
+  renderWithProvider();
+
+  await act(async () => {
+    await ctxRef.startCall({
+      calleeId: 24,
+      mode: 'AUDIO',
+      peerName: 'Reviewer',
+    });
+  });
+
+  expect(ctxRef.active).toMatchObject({
+    callId: 'call-123',
+    peerId: 24,
+    mode: 'AUDIO',
+    mediaTransport: 'twilio-voice',
+  });
+
+  mockTwilioHangup.mockClear();
+
+  act(() => {
+    socketMock.emit('call:ended', {
+      callId: 'call-123',
+      status: 'DECLINED',
+    });
+  });
+
+  expect(mockTwilioHangup).toHaveBeenCalledTimes(1);
+  expect(ctxRef.active).toBeNull();
+  expect(ctxRef.pending).toBe(false);
+  expect(ctxRef.status).toBeNull();
 });
 
 test('call:ended socket event triggers cleanup', async () => {


### PR DESCRIPTION
## Summary
- make `CallContext` consume the authenticated socket from `SocketContext`
- remove reliance on the disconnected `@/lib/socket` singleton for call lifecycle events
- rebind call listeners when the authoritative socket instance changes
- add regression coverage proving an outgoing audio call cleans up immediately when the callee declines

## Validation
- `npm test -- --runInBand src/context/__tests__/CallContext.test.js`
- 12/12 focused tests passing

This fixes the production case where Android declined immediately but the website kept showing `Connecting…` until Twilio's ~15 second timeout.