### PR TITLE
Notify caller when app call times out

### DIFF
--- a/server/__tests__/voiceWebhooks.test.js
+++ b/server/__tests__/voiceWebhooks.test.js
@@ -710,6 +710,16 @@ describe('POST /webhooks/voice/app-call-complete', () => {
     );
 
     expect(emitToUser).toHaveBeenCalledWith(
+      42,
+      'call:ended',
+      expect.objectContaining({
+        callId: 777,
+        status: 'MISSED',
+        reason: 'no_answer',
+      })
+    );
+
+    expect(emitToUser).toHaveBeenCalledWith(
       99,
       'call:ended',
       expect.objectContaining({

--- a/server/routes/voiceWebhooks.js
+++ b/server/routes/voiceWebhooks.js
@@ -674,9 +674,11 @@ router.post('/app-call-complete', async (req, res) => {
           forwarded: false,
         };
 
-        if (dialCallStatus === 'completed') {
-          emitToUser(updated.callerId, 'call:ended', endedPayload);
-        }
+        emitToUser(
+          updated.callerId,
+          'call:ended',
+          endedPayload
+        );
 
         if (
           updated.calleeId &&


### PR DESCRIPTION
## Summary
- emit `call:ended` to the caller whenever `/webhooks/voice/app-call-complete` finalizes an app-to-app call
- preserve callee notification behavior
- add regression coverage requiring both caller and callee to receive `MISSED / no_answer` on timeout

## Validation
- `npm test -- --runInBand --coverage=false __tests__/voiceWebhooks.test.js`
- 20/20 focused tests passing

This fixes the production case where an unanswered Android call correctly became `MISSED / no_answer` and entered voicemail, but the originating website continued showing the call prompt because the caller never received the terminal realtime event.