### PR TITLE
Preserve Twilio call during voicemail handoff

### DIFF
--- a/client/src/context/CallContext.jsx
+++ b/client/src/context/CallContext.jsx
@@ -198,6 +198,24 @@ const twilioVideoRoomRef = useRef(null);
       return;
     }
 
+    const reason =
+      String(payload?.reason || '')
+        .trim()
+        .toLowerCase();
+
+    const isOutgoingTwilioVoicemailHandoff =
+      status === 'MISSED' &&
+      reason === 'no_answer' &&
+      activeRef.current?.mediaTransport ===
+        'twilio-voice';
+
+    if (isOutgoingTwilioVoicemailHandoff) {
+      cleanup({
+        preserveTwilioVoice: true,
+      });
+      return;
+    }
+
     cleanup();
   }
 
@@ -1031,10 +1049,14 @@ function onParticipantDeclined({ participant }) {
   delete peerConnectionsRef.current[key];
 }
 
-  function cleanup() {
+  function cleanup({
+  preserveTwilioVoice = false,
+} = {}) {
+if (!preserveTwilioVoice) {
 try {
 twilioVoice.hangup();
 } catch {}
+}
 
 const videoRoom =
 twilioVideoRoomRef.current;

--- a/client/src/context/__tests__/CallContext.test.js
+++ b/client/src/context/__tests__/CallContext.test.js
@@ -697,6 +697,46 @@ test('outgoing audio call cleans up immediately when callee declines', async () 
   expect(ctxRef.status).toBeNull();
 });
 
+test(
+  'outgoing audio timeout clears UI without hanging up Twilio so voicemail can continue',
+  async () => {
+    renderWithProvider();
+
+    await act(async () => {
+      await ctxRef.startCall({
+        calleeId: 24,
+        mode: 'AUDIO',
+        peerName: 'Reviewer',
+      });
+    });
+
+    expect(ctxRef.active).toMatchObject({
+      callId: 'call-123',
+      peerId: 24,
+      mode: 'AUDIO',
+      mediaTransport: 'twilio-voice',
+    });
+
+    mockTwilioHangup.mockClear();
+
+    act(() => {
+      socketMock.emit('call:ended', {
+        callId: 'call-123',
+        status: 'MISSED',
+        reason: 'no_answer',
+      });
+    });
+
+    expect(
+      mockTwilioHangup
+    ).not.toHaveBeenCalled();
+
+    expect(ctxRef.active).toBeNull();
+    expect(ctxRef.pending).toBe(false);
+    expect(ctxRef.status).toBeNull();
+  }
+);
+
 test('call:ended socket event triggers cleanup', async () => {
     renderWithProvider();
 


### PR DESCRIPTION
## Summary
- clear the web call UI on `MISSED / no_answer` without hanging up the browser Twilio Voice leg
- preserve normal Twilio hangup behavior for other terminal call states
- add a regression test covering voicemail handoff behavior

## Validation
- `CallContext.test.js`: 13/13 tests passed with `--coverage=false`
- `git diff --check` clean

This fixes the timeout -> voicemail regression introduced when the web caller began receiving real-time `call:ended` events on no-answer.