### PR TITLE
Keep call controls visible during voicemail

### DIFF
--- a/client/src/context/CallContext.jsx
+++ b/client/src/context/CallContext.jsx
@@ -210,9 +210,8 @@ const twilioVideoRoomRef = useRef(null);
         'twilio-voice';
 
     if (isOutgoingTwilioVoicemailHandoff) {
-      cleanup({
-        preserveTwilioVoice: true,
-      });
+      setPending(false);
+      setStatus('Voicemail');
       return;
     }
 

--- a/client/src/context/__tests__/CallContext.test.js
+++ b/client/src/context/__tests__/CallContext.test.js
@@ -698,7 +698,7 @@ test('outgoing audio call cleans up immediately when callee declines', async () 
 });
 
 test(
-  'outgoing audio timeout clears UI without hanging up Twilio so voicemail can continue',
+  'outgoing audio timeout keeps call UI active during voicemail without hanging up Twilio',
   async () => {
     renderWithProvider();
 
@@ -731,9 +731,15 @@ test(
       mockTwilioHangup
     ).not.toHaveBeenCalled();
 
-    expect(ctxRef.active).toBeNull();
+    expect(ctxRef.active).toMatchObject({
+      callId: 'call-123',
+      peerId: 24,
+      mode: 'AUDIO',
+      mediaTransport: 'twilio-voice',
+    });
+
     expect(ctxRef.pending).toBe(false);
-    expect(ctxRef.status).toBeNull();
+    expect(ctxRef.status).toBe('Voicemail');
   }
 );
 


### PR DESCRIPTION
## Summary
- keep the outgoing Twilio Voice call active in web UI during voicemail handoff
- transition the call status to `Voicemail` instead of clearing the active call
- preserve the End Call control while voicemail greeting/recording continues
- update the CallContext regression test accordingly

## Validation
- `client/src/context/__tests__/CallContext.test.js`: 13/13 tests passed with `--coverage=false`
- `git diff --check` clean