### PR TITLE
Clear Voice registration on device logout

### DIFF
--- a/server/__tests__/devices.test.js
+++ b/server/__tests__/devices.test.js
@@ -416,6 +416,10 @@ describe('Device logout', () => {
         fcmPushToken: null,
         voipPushToken: null,
         voipSandboxPushToken: null,
+        voiceIdentity: null,
+        voiceRegisteredAt: null,
+        voiceRegistrationVer: 0,
+        voicePushEnvironment: null,
         lastSeenAt: expect.any(Date),
       },
     });

--- a/server/routes/devices.js
+++ b/server/routes/devices.js
@@ -814,6 +814,12 @@ router.post('/logout', requireAuth, async (req, res, next) => {
         fcmPushToken: null,
         voipPushToken: null,
         voipSandboxPushToken: null,
+
+        voiceIdentity: null,
+        voiceRegisteredAt: null,
+        voiceRegistrationVer: 0,
+        voicePushEnvironment: null,
+
         lastSeenAt: new Date(),
       },
     });


### PR DESCRIPTION
## Summary
- clear device-specific Twilio Voice registration authority when a device logs out
- keep logout non-revoking while removing Voice eligibility for the signed-out installation
- extend device logout regression coverage to verify Voice registration fields are cleared

## Validation
- `__tests__/devices.test.js`
- `__tests__/voiceDeviceService.test.js`
- 29/29 targeted tests passing with coverage disabled

This closes the gap where a signed-out Android or iOS device could remain eligible for incoming Twilio Voice fanout even after notification push credentials were cleared.