### PR TITLE
Add device-authoritative call lifecycle

### DIFF
--- a/server/__tests__/calls.routes.test.js
+++ b/server/__tests__/calls.routes.test.js
@@ -11,6 +11,9 @@ const mockPrisma = {
   user: {
     findUnique: jest.fn(),
   },
+  device: {
+    findUnique: jest.fn(),
+  },
   call: {
     create: jest.fn(),
     findFirst: jest.fn(),
@@ -90,6 +93,10 @@ describe('calls routes', () => {
       .mockResolvedValue(undefined);
 
     mockPrisma.user.findUnique.mockReset();
+
+    mockPrisma.device.findUnique
+      .mockReset()
+      .mockResolvedValue(null);
 
     mockPrisma.call.create.mockReset();
     mockPrisma.call.findFirst
@@ -752,6 +759,99 @@ describe('calls routes', () => {
       expect(emitToUserMock).not.toHaveBeenCalled();
       expect(mockPrisma.call.findUnique).toHaveBeenCalledTimes(1);
     });
+
+    test('a losing callee device cannot end an active call won by another device', async () => {
+      mockPrisma.call.findUnique.mockResolvedValueOnce({
+        id: 730,
+        callerId: 20,
+        calleeId: 10,
+        mode: 'AUDIO',
+        status: 'ACTIVE',
+        answeredDeviceId: 'iphone-device',
+        answeredVoiceIdentity:
+          'user_10_device_iphone_device',
+        participants: [
+          { userId: 20 },
+          { userId: 10 },
+        ],
+      });
+
+      const res = await request(app)
+        .post('/calls/end')
+        .send({
+          callId: 730,
+          reason: 'hangup',
+          deviceId: 'android-device',
+        });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body).toEqual({
+        ok: true,
+        ignored: true,
+        code: 'CALL_NOT_AUTHORITATIVE_DEVICE',
+      });
+
+      expect(
+        mockPrisma.call.updateMany
+      ).not.toHaveBeenCalled();
+
+      expect(
+        emitToUserMock
+      ).not.toHaveBeenCalled();
+    });
+
+    test('the winning callee device may end its active call', async () => {
+      const endedAt =
+        new Date('2026-08-11T02:00:00.000Z');
+
+      mockPrisma.call.findUnique
+        .mockResolvedValueOnce({
+          id: 731,
+          callerId: 20,
+          calleeId: 10,
+          mode: 'AUDIO',
+          status: 'ACTIVE',
+          answeredDeviceId: 'android-device',
+          answeredVoiceIdentity:
+            'user_10_device_android_device',
+          participants: [
+            { userId: 20 },
+            { userId: 10 },
+          ],
+        })
+        .mockResolvedValueOnce({
+          id: 731,
+          callerId: 20,
+          calleeId: 10,
+          status: 'ENDED',
+          endedAt,
+          durationSec: undefined,
+          endReason: 'hangup',
+        });
+
+      mockPrisma.call.updateMany
+        .mockResolvedValueOnce({
+          count: 1,
+        });
+
+      const res = await request(app)
+        .post('/calls/end')
+        .send({
+          callId: 731,
+          reason: 'hangup',
+          deviceId: 'android-device',
+        });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body).toEqual({
+        ok: true,
+      });
+
+      expect(
+        mockPrisma.call.updateMany
+      ).toHaveBeenCalledTimes(1);
+    });
+
   });
 
   describe('PATCH /calls/:id/status', () => {
@@ -864,5 +964,369 @@ describe('calls routes', () => {
         emitToUserMock
       ).not.toHaveBeenCalled();
     });
+    test('an eligible callee device atomically becomes the physical answer winner', async () => {
+      const startedAt =
+        new Date('2026-08-11T02:05:00.000Z');
+
+      mockPrisma.call.findUnique
+        .mockResolvedValueOnce({
+          id: 740,
+          callerId: 20,
+          calleeId: 10,
+          mode: 'AUDIO',
+          status: 'RINGING',
+          startedAt: null,
+          endedAt: null,
+          durationSec: null,
+          endReason: null,
+          twilioCallSid: null,
+          answeredDeviceId: null,
+          answeredVoiceIdentity: null,
+          participants: [
+            { userId: 20 },
+            { userId: 10 },
+          ],
+        })
+        .mockResolvedValueOnce({
+          id: 740,
+          callerId: 20,
+          calleeId: 10,
+          mode: 'AUDIO',
+          status: 'ACTIVE',
+          startedAt,
+          endedAt: null,
+          durationSec: null,
+          endReason: null,
+          twilioCallSid: null,
+          answeredDeviceId: 'android-device',
+          answeredVoiceIdentity:
+            'user_10_device_android_device',
+        });
+
+      mockPrisma.device.findUnique
+        .mockResolvedValueOnce({
+          deviceId: 'android-device',
+          platform: 'android',
+          pairingStatus: 'approved',
+          revokedAt: null,
+          voiceIdentity:
+            'user_10_device_android_device',
+          voiceRegisteredAt:
+            new Date('2026-08-11T01:00:00.000Z'),
+          voiceRegistrationVer: 1,
+          voicePushEnvironment: null,
+        });
+
+      mockPrisma.call.updateMany
+        .mockResolvedValueOnce({
+          count: 1,
+        });
+
+      const res = await request(app)
+        .patch('/calls/740/status')
+        .send({
+          status: 'ACTIVE',
+          startedAt:
+            startedAt.toISOString(),
+          deviceId: 'android-device',
+        });
+
+      expect(res.statusCode).toBe(200);
+
+      expect(
+        mockPrisma.device.findUnique
+      ).toHaveBeenCalledWith({
+        where: {
+          userId_deviceId: {
+            userId: 10,
+            deviceId: 'android-device',
+          },
+        },
+        select: {
+          deviceId: true,
+          platform: true,
+          pairingStatus: true,
+          revokedAt: true,
+          voiceIdentity: true,
+          voiceRegisteredAt: true,
+          voiceRegistrationVer: true,
+          voicePushEnvironment: true,
+        },
+      });
+
+      expect(
+        mockPrisma.call.updateMany
+      ).toHaveBeenCalledWith({
+        where: {
+          id: 740,
+          status: {
+            in: [
+              'RINGING',
+              'INITIATED',
+            ],
+          },
+        },
+        data: expect.objectContaining({
+          status: 'ACTIVE',
+          answeredDeviceId:
+            'android-device',
+          answeredVoiceIdentity:
+            'user_10_device_android_device',
+        }),
+      });
+    });
+
+    test('the winning physical device may retry ACTIVE idempotently', async () => {
+      mockPrisma.call.findUnique
+        .mockResolvedValueOnce({
+          id: 741,
+          callerId: 20,
+          calleeId: 10,
+          mode: 'AUDIO',
+          status: 'ACTIVE',
+          startedAt:
+            new Date('2026-08-11T02:06:00.000Z'),
+          endedAt: null,
+          durationSec: null,
+          endReason: null,
+          twilioCallSid: null,
+          answeredDeviceId: 'iphone-device',
+          answeredVoiceIdentity:
+            'user_10_device_iphone_device',
+          participants: [
+            { userId: 20 },
+            { userId: 10 },
+          ],
+        });
+
+      const res = await request(app)
+        .patch('/calls/741/status')
+        .send({
+          status: 'ACTIVE',
+          deviceId: 'iphone-device',
+        });
+
+      expect(res.statusCode).toBe(200);
+
+      expect(res.body.call).toMatchObject({
+        id: 741,
+        status: 'ACTIVE',
+        answeredDeviceId:
+          'iphone-device',
+      });
+
+      expect(
+        mockPrisma.device.findUnique
+      ).not.toHaveBeenCalled();
+
+      expect(
+        mockPrisma.call.updateMany
+      ).not.toHaveBeenCalled();
+    });
+
+    test('a different physical device receives answered elsewhere after a winner exists', async () => {
+      mockPrisma.call.findUnique
+        .mockResolvedValueOnce({
+          id: 742,
+          callerId: 20,
+          calleeId: 10,
+          mode: 'AUDIO',
+          status: 'ACTIVE',
+          startedAt:
+            new Date('2026-08-11T02:07:00.000Z'),
+          endedAt: null,
+          durationSec: null,
+          endReason: null,
+          twilioCallSid: null,
+          answeredDeviceId: 'iphone-device',
+          answeredVoiceIdentity:
+            'user_10_device_iphone_device',
+          participants: [
+            { userId: 20 },
+            { userId: 10 },
+          ],
+        });
+
+      const res = await request(app)
+        .patch('/calls/742/status')
+        .send({
+          status: 'ACTIVE',
+          deviceId: 'android-device',
+        });
+
+      expect(res.statusCode).toBe(409);
+
+      expect(res.body).toMatchObject({
+        code: 'CALL_ANSWERED_ELSEWHERE',
+        callId: 742,
+        status: 'ACTIVE',
+      });
+
+      expect(
+        mockPrisma.call.updateMany
+      ).not.toHaveBeenCalled();
+    });
+
+    test('a video ACTIVE claim is not gated by Twilio Voice device eligibility', async () => {
+      mockPrisma.call.findUnique
+        .mockResolvedValueOnce({
+          id: 745,
+          callerId: 20,
+          calleeId: 10,
+          mode: 'VIDEO',
+          status: 'RINGING',
+          startedAt: null,
+          endedAt: null,
+          durationSec: null,
+          endReason: null,
+          twilioCallSid: null,
+          answeredDeviceId: null,
+          answeredVoiceIdentity: null,
+          participants: [
+            { userId: 20 },
+            { userId: 10 },
+          ],
+        })
+        .mockResolvedValueOnce({
+          id: 745,
+          callerId: 20,
+          calleeId: 10,
+          mode: 'VIDEO',
+          status: 'ACTIVE',
+          startedAt:
+            new Date('2026-08-11T02:09:00.000Z'),
+          endedAt: null,
+          durationSec: null,
+          endReason: null,
+          twilioCallSid: null,
+          answeredDeviceId: null,
+          answeredVoiceIdentity: null,
+        });
+
+      mockPrisma.call.updateMany
+        .mockResolvedValueOnce({
+          count: 1,
+        });
+
+      const res = await request(app)
+        .patch('/calls/745/status')
+        .send({
+          status: 'ACTIVE',
+          deviceId: 'video-device',
+        });
+
+      expect(res.statusCode).toBe(200);
+
+      expect(
+        mockPrisma.device.findUnique
+      ).not.toHaveBeenCalled();
+
+      expect(
+        mockPrisma.call.updateMany
+      ).toHaveBeenCalledWith({
+        where: {
+          id: 745,
+          status: {
+            in: [
+              'RINGING',
+              'INITIATED',
+            ],
+          },
+        },
+        data: expect.objectContaining({
+          status: 'ACTIVE',
+          answeredDeviceId: undefined,
+          answeredVoiceIdentity: undefined,
+        }),
+      });
+    });
+
+    test('an ineligible physical device cannot claim a ringing call', async () => {
+      mockPrisma.call.findUnique
+        .mockResolvedValueOnce({
+          id: 743,
+          callerId: 20,
+          calleeId: 10,
+          mode: 'AUDIO',
+          status: 'RINGING',
+          answeredDeviceId: null,
+          participants: [
+            { userId: 20 },
+            { userId: 10 },
+          ],
+        });
+
+      mockPrisma.device.findUnique
+        .mockResolvedValueOnce(null);
+
+      const res = await request(app)
+        .patch('/calls/743/status')
+        .send({
+          status: 'ACTIVE',
+          deviceId: 'unknown-device',
+        });
+
+      expect(res.statusCode).toBe(409);
+
+      expect(res.body).toMatchObject({
+        code: 'CALL_DEVICE_NOT_ELIGIBLE',
+        callId: 743,
+      });
+
+      expect(
+        mockPrisma.call.updateMany
+      ).not.toHaveBeenCalled();
+    });
+
+    test('a losing callee device cannot terminate the physical winner through status PATCH', async () => {
+      mockPrisma.call.findUnique
+        .mockResolvedValueOnce({
+          id: 744,
+          callerId: 20,
+          calleeId: 10,
+          mode: 'AUDIO',
+          status: 'ACTIVE',
+          startedAt:
+            new Date('2026-08-11T02:08:00.000Z'),
+          endedAt: null,
+          durationSec: null,
+          endReason: null,
+          twilioCallSid: null,
+          answeredDeviceId: 'iphone-device',
+          answeredVoiceIdentity:
+            'user_10_device_iphone_device',
+          participants: [
+            { userId: 20 },
+            { userId: 10 },
+          ],
+        });
+
+      const res = await request(app)
+        .patch('/calls/744/status')
+        .send({
+          status: 'ENDED',
+          endReason: 'hangup',
+          deviceId: 'android-device',
+        });
+
+      expect(res.statusCode).toBe(200);
+
+      expect(res.body.call).toMatchObject({
+        id: 744,
+        status: 'ACTIVE',
+        answeredDeviceId:
+          'iphone-device',
+      });
+
+      expect(
+        mockPrisma.call.updateMany
+      ).not.toHaveBeenCalled();
+
+      expect(
+        emitToUserMock
+      ).not.toHaveBeenCalled();
+    });
+
+
   });
 });

--- a/server/prisma/migrations/20260811020000_add_call_answer_device_authority/migration.sql
+++ b/server/prisma/migrations/20260811020000_add_call_answer_device_authority/migration.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "Call"
+ADD COLUMN "answeredDeviceId" TEXT,
+ADD COLUMN "answeredVoiceIdentity" TEXT;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -1405,17 +1405,19 @@ model Call {
 
   externalPhone String?
 
-  offerSdp      String?
-  answerSdp     String?
-  createdAt     DateTime          @default(now())
-  startedAt     DateTime?
-  endedAt       DateTime?
-  twilioCallSid String?           @unique
-  durationSec   Int?
-  endReason     String?
-  fromLabel     String?
-  toLabel       String?
-  participants  CallParticipant[]
+  offerSdp              String?
+  answerSdp             String?
+  createdAt             DateTime          @default(now())
+  startedAt             DateTime?
+  endedAt               DateTime?
+  twilioCallSid         String?           @unique
+  answeredDeviceId      String?
+  answeredVoiceIdentity String?
+  durationSec           Int?
+  endReason             String?
+  fromLabel             String?
+  toLabel               String?
+  participants          CallParticipant[]
 
   caller User  @relation("CallCaller", fields: [callerId], references: [id])
   callee User? @relation("CallCallee", fields: [calleeId], references: [id])

--- a/server/routes/calls.js
+++ b/server/routes/calls.js
@@ -6,6 +6,7 @@ import { requireAuth } from '../middleware/auth.js';
 import { sendPushToUser, sendVoipCallPushToUser } from '../services/pushService.js';
 import { collectCallLifecycleRecipientIds } from '../utils/callLifecycleRecipients.js';
 import { claimCallActive } from '../utils/callAnswerArbitration.js';
+import { isVoiceEligibleDevice } from '../services/voiceDeviceService.js';
 
 const router = express.Router();
 router.use(requireAuth);
@@ -36,6 +37,63 @@ async function ensureParticipant(call, userId) {
   });
 
   return Boolean(participant);
+}
+
+async function resolveEligibleVoiceDevice(
+  userId,
+  deviceId
+) {
+  const normalizedDeviceId =
+    String(deviceId || '').trim();
+
+  if (!normalizedDeviceId) {
+    return null;
+  }
+
+  const device = await prisma.device.findUnique({
+    where: {
+      userId_deviceId: {
+        userId: Number(userId),
+        deviceId: normalizedDeviceId,
+      },
+    },
+    select: {
+      deviceId: true,
+      platform: true,
+      pairingStatus: true,
+      revokedAt: true,
+      voiceIdentity: true,
+      voiceRegisteredAt: true,
+      voiceRegistrationVer: true,
+      voicePushEnvironment: true,
+    },
+  });
+
+  if (!isVoiceEligibleDevice(device, userId)) {
+    return null;
+  }
+
+  return device;
+}
+
+function isNonAuthoritativeActiveCalleeDevice({
+  call,
+  userId,
+  deviceId,
+}) {
+  if (
+    !call ||
+    call.status !== 'ACTIVE' ||
+    Number(userId) !== Number(call.calleeId) ||
+    !call.answeredDeviceId
+  ) {
+    return false;
+  }
+
+  return (
+    String(deviceId || '').trim() !==
+    String(call.answeredDeviceId).trim()
+  );
 }
 
 async function notifyAnsweredElsewhere(call) {
@@ -617,7 +675,12 @@ router.post('/candidate', asyncHandler(async (req, res) => {
  */
 router.post('/end', asyncHandler(async (req, res) => {
   const userId = Number(req.user.id);
-  const { callId, reason, durationSec } = req.body || {};
+  const {
+    callId,
+    reason,
+    durationSec,
+    deviceId,
+  } = req.body || {};
 
   if (!callId) {
     return res.status(400).json({ error: 'callId required' });
@@ -631,6 +694,39 @@ router.post('/end', asyncHandler(async (req, res) => {
   if (!call) return res.status(404).json({ error: 'Call not found' });
   if (!(await ensureParticipant(call, userId))) {
     return res.status(403).json({ error: 'Not a participant' });
+  }
+
+  /*
+   * Once an ACTIVE call has a recorded physical winner,
+   * only that winning callee installation may finalize it.
+   *
+   * Caller authority remains unchanged.
+   * Pre-answer decline/missed behavior remains unchanged.
+   */
+  if (
+    isNonAuthoritativeActiveCalleeDevice({
+      call,
+      userId,
+      deviceId,
+    })
+  ) {
+    console.log(
+      '[calls/end] ignored non-authoritative callee device',
+      {
+        callId: call.id,
+        userId,
+        reportedDeviceId:
+          String(deviceId || '').trim() || null,
+        answeredDeviceId:
+          call.answeredDeviceId,
+      }
+    );
+
+    return res.json({
+      ok: true,
+      ignored: true,
+      code: 'CALL_NOT_AUTHORITATIVE_DEVICE',
+    });
   }
 
   let status = 'ENDED';
@@ -787,6 +883,7 @@ router.patch('/:id/status', asyncHandler(async (req, res) => {
     durationSec,
     endReason,
     twilioCallSid,
+    deviceId,
   } = req.body || {};
 
   const call = await prisma.call.findUnique({
@@ -807,6 +904,138 @@ router.patch('/:id/status', asyncHandler(async (req, res) => {
     endReason == null
       ? null
       : String(endReason).trim().toLowerCase();
+
+  /*
+   * If the physical device that already won retries ACTIVE,
+   * treat the request as idempotent. The original HTTP response
+   * may have been lost after the database transition committed.
+   */
+  if (
+    normalizedStatus === 'ACTIVE' &&
+    call.status === 'ACTIVE' &&
+    userId === call.calleeId &&
+    call.answeredDeviceId &&
+    String(deviceId || '').trim() ===
+      String(call.answeredDeviceId).trim()
+  ) {
+    return res.json({
+      call: {
+        id: call.id,
+        callerId: call.callerId,
+        calleeId: call.calleeId,
+        mode: call.mode,
+        status: call.status,
+        startedAt: call.startedAt,
+        endedAt: call.endedAt,
+        durationSec: call.durationSec,
+        endReason: call.endReason,
+        twilioCallSid: call.twilioCallSid,
+        answeredDeviceId:
+          call.answeredDeviceId,
+        answeredVoiceIdentity:
+          call.answeredVoiceIdentity,
+      },
+    });
+  }
+
+  /*
+   * A different physical callee device cannot claim an
+   * already-ACTIVE call that has a recorded winner.
+   */
+  if (
+    normalizedStatus === 'ACTIVE' &&
+    call.status === 'ACTIVE' &&
+    userId === call.calleeId &&
+    call.answeredDeviceId
+  ) {
+    return res.status(409).json({
+      error:
+        'This call was answered on another device.',
+      code: 'CALL_ANSWERED_ELSEWHERE',
+      callId,
+      status: call.status,
+    });
+  }
+
+  let answeringDevice = null;
+
+  /*
+   * Supported mobile clients supply their stable installation
+   * deviceId. Validate it against the same server-side Voice
+   * authority used for Twilio fan-out.
+   *
+   * deviceId remains optional temporarily for rollout
+   * compatibility with existing clients.
+   */
+  if (
+    normalizedStatus === 'ACTIVE' &&
+    call.mode === 'AUDIO' &&
+    userId === call.calleeId &&
+    deviceId != null
+  ) {
+    answeringDevice =
+      await resolveEligibleVoiceDevice(
+        userId,
+        deviceId
+      );
+
+    if (!answeringDevice) {
+      return res.status(409).json({
+        error:
+          'This device is not eligible to answer this call.',
+        code: 'CALL_DEVICE_NOT_ELIGIBLE',
+        callId,
+      });
+    }
+  }
+
+  /*
+   * After a physical winner exists, a losing callee device may
+   * clean up its local leg but cannot terminate the canonical
+   * ACTIVE call. Caller authority is intentionally unaffected.
+   */
+  if (
+    isTerminalCallStatus(normalizedStatus) &&
+    isNonAuthoritativeActiveCalleeDevice({
+      call,
+      userId,
+      deviceId,
+    })
+  ) {
+    console.log(
+      '[calls/status] ignored non-authoritative callee device',
+      {
+        callId,
+        reportedBy: userId,
+        reportedDeviceId:
+          String(deviceId || '').trim() || null,
+        answeredDeviceId:
+          call.answeredDeviceId,
+        reportedStatus: normalizedStatus,
+        reportedEndReason:
+          normalizedEndReason,
+      }
+    );
+
+    return res.json({
+      call: {
+        id: call.id,
+        callerId: call.callerId,
+        calleeId: call.calleeId,
+        mode: call.mode,
+        status: call.status,
+        startedAt: call.startedAt,
+        endedAt: call.endedAt,
+        durationSec: call.durationSec,
+        endReason: call.endReason,
+        twilioCallSid: call.twilioCallSid,
+        answeredDeviceId:
+          call.answeredDeviceId,
+        answeredVoiceIdentity:
+          call.answeredVoiceIdentity,
+      },
+    });
+  }
 
   const isRemoteEndedAcknowledgement =
     isTerminalCallStatus(normalizedStatus) &&
@@ -877,6 +1106,18 @@ router.patch('/:id/status', asyncHandler(async (req, res) => {
     endedAt: endedAt ? new Date(endedAt) : undefined,
     durationSec: durationSec ?? undefined,
     endReason: endReason ?? undefined,
+    answeredDeviceId:
+      normalizedStatus === 'ACTIVE' &&
+      call.mode === 'AUDIO' &&
+      answeringDevice
+        ? answeringDevice.deviceId
+        : undefined,
+    answeredVoiceIdentity:
+      normalizedStatus === 'ACTIVE' &&
+      call.mode === 'AUDIO' &&
+      answeringDevice
+        ? answeringDevice.voiceIdentity
+        : undefined,
   };
 
   if (twilioCallSid) {
@@ -933,6 +1174,8 @@ const lifecycleUpdate =
       durationSec: true,
       endReason: true,
       twilioCallSid: true,
+      answeredDeviceId: true,
+      answeredVoiceIdentity: true,
     },
   });
 


### PR DESCRIPTION
## Summary
- add authoritative physical-device winner fields to `Call`
- validate AUDIO answer claims against server Voice registration authority
- make same-device ACTIVE retries idempotent
- prevent losing callee devices from terminating the canonical ACTIVE call via `/calls/end` or `PATCH /calls/:id/status`
- keep VIDEO answer handling independent from Twilio Voice registration
- add focused regression coverage for winner/loser behavior and rollout compatibility

## Validation
- `node --check routes/calls.js`
- `npx prisma validate`
- focused call/Voice tests: 45/45 passed
- full server suite: 215/215 suites, 1377/1377 tests passed

## Migration
Adds nullable `Call.answeredDeviceId` and `Call.answeredVoiceIdentity` fields.