### PR TITLE
Add authoritative device handling for video calls

### DIFF
--- a/server/__tests__/calls.routes.test.js
+++ b/server/__tests__/calls.routes.test.js
@@ -1167,7 +1167,10 @@ describe('calls routes', () => {
       ).not.toHaveBeenCalled();
     });
 
-    test('a video ACTIVE claim is not gated by Twilio Voice device eligibility', async () => {
+    test('an active registered video device becomes the physical answer winner', async () => {
+      const startedAt =
+        new Date('2026-08-11T02:09:00.000Z');
+
       mockPrisma.call.findUnique
         .mockResolvedValueOnce({
           id: 745,
@@ -1193,14 +1196,20 @@ describe('calls routes', () => {
           calleeId: 10,
           mode: 'VIDEO',
           status: 'ACTIVE',
-          startedAt:
-            new Date('2026-08-11T02:09:00.000Z'),
+          startedAt,
           endedAt: null,
           durationSec: null,
           endReason: null,
           twilioCallSid: null,
-          answeredDeviceId: null,
+          answeredDeviceId: 'video-device',
           answeredVoiceIdentity: null,
+        });
+
+      mockPrisma.device.findUnique
+        .mockResolvedValueOnce({
+          deviceId: 'video-device',
+          pairingStatus: 'approved',
+          revokedAt: null,
         });
 
       mockPrisma.call.updateMany
@@ -1212,6 +1221,8 @@ describe('calls routes', () => {
         .patch('/calls/745/status')
         .send({
           status: 'ACTIVE',
+          startedAt:
+            startedAt.toISOString(),
           deviceId: 'video-device',
         });
 
@@ -1219,7 +1230,19 @@ describe('calls routes', () => {
 
       expect(
         mockPrisma.device.findUnique
-      ).not.toHaveBeenCalled();
+      ).toHaveBeenCalledWith({
+        where: {
+          userId_deviceId: {
+            userId: 10,
+            deviceId: 'video-device',
+          },
+        },
+        select: {
+          deviceId: true,
+          pairingStatus: true,
+          revokedAt: true,
+        },
+      });
 
       expect(
         mockPrisma.call.updateMany
@@ -1235,10 +1258,65 @@ describe('calls routes', () => {
         },
         data: expect.objectContaining({
           status: 'ACTIVE',
-          answeredDeviceId: undefined,
+          answeredDeviceId: 'video-device',
           answeredVoiceIdentity: undefined,
         }),
       });
+    });
+
+    test('a callee device local failure cannot terminate a ringing multi-device video call', async () => {
+      mockPrisma.call.findUnique
+        .mockResolvedValueOnce({
+          id: 746,
+          callerId: 20,
+          calleeId: 10,
+          mode: 'VIDEO',
+          status: 'RINGING',
+          startedAt: null,
+          endedAt: null,
+          durationSec: null,
+          endReason: null,
+          twilioCallSid: null,
+          answeredDeviceId: null,
+          answeredVoiceIdentity: null,
+          participants: [
+            { userId: 20 },
+            { userId: 10 },
+          ],
+        });
+
+      const res = await request(app)
+        .patch('/calls/746/status')
+        .send({
+          status: 'FAILED',
+          endedAt:
+            '2026-08-11T02:09:05.000Z',
+          endReason:
+            'Local video audio initialization failed.',
+          deviceId: 'stale-video-device',
+        });
+
+      expect(res.statusCode).toBe(200);
+
+      expect(res.body).toMatchObject({
+        ignored: true,
+        code:
+          'CALL_DEVICE_LOCAL_FAILURE_IGNORED',
+        call: {
+          id: 746,
+          status: 'RINGING',
+          endedAt: null,
+          endReason: null,
+        },
+      });
+
+      expect(
+        mockPrisma.call.updateMany
+      ).not.toHaveBeenCalled();
+
+      expect(
+        emitToUserMock
+      ).not.toHaveBeenCalled();
     });
 
     test('an ineligible physical device cannot claim a ringing call', async () => {

--- a/server/routes/calls.js
+++ b/server/routes/calls.js
@@ -969,15 +969,50 @@ router.patch('/:id/status', asyncHandler(async (req, res) => {
    */
   if (
     normalizedStatus === 'ACTIVE' &&
-    call.mode === 'AUDIO' &&
     userId === call.calleeId &&
     deviceId != null
   ) {
-    answeringDevice =
-      await resolveEligibleVoiceDevice(
-        userId,
-        deviceId
-      );
+    if (call.mode === 'AUDIO') {
+      answeringDevice =
+        await resolveEligibleVoiceDevice(
+          userId,
+          deviceId
+        );
+    } else {
+      const registeredDevice =
+        await prisma.device.findUnique({
+          where: {
+            userId_deviceId: {
+              userId,
+              deviceId:
+                String(deviceId).trim(),
+            },
+          },
+          select: {
+            deviceId: true,
+            pairingStatus: true,
+            revokedAt: true,
+          },
+        });
+
+      const pairingStatus =
+        String(
+          registeredDevice?.pairingStatus || ''
+        )
+          .trim()
+          .toLowerCase();
+
+      if (
+        registeredDevice &&
+        !registeredDevice.revokedAt &&
+        (
+          !pairingStatus ||
+          pairingStatus === 'approved'
+        )
+      ) {
+        answeringDevice = registeredDevice;
+      }
+    }
 
     if (!answeringDevice) {
       return res.status(409).json({
@@ -987,6 +1022,52 @@ router.patch('/:id/status', asyncHandler(async (req, res) => {
         callId,
       });
     }
+  }
+
+  /*
+   * A callee device can fail to initialize its own local media
+   * while the same account is still ringing on another device.
+   * That local failure must not terminate the canonical call.
+   * Reconciliation will finalize the call if nobody answers.
+   */
+  if (
+    normalizedStatus === 'FAILED' &&
+    userId === call.calleeId &&
+    ['RINGING', 'INITIATED'].includes(call.status)
+  ) {
+    console.log(
+      '[calls/status] ignored ringing callee device failure',
+      {
+        callId,
+        reportedBy: userId,
+        reportedDeviceId:
+          String(deviceId || '').trim() || null,
+        reportedEndReason:
+          normalizedEndReason,
+        authoritativeStatus: call.status,
+      }
+    );
+
+    return res.json({
+      call: {
+        id: call.id,
+        callerId: call.callerId,
+        calleeId: call.calleeId,
+        mode: call.mode,
+        status: call.status,
+        startedAt: call.startedAt,
+        endedAt: call.endedAt,
+        durationSec: call.durationSec,
+        endReason: call.endReason,
+        twilioCallSid: call.twilioCallSid,
+        answeredDeviceId:
+          call.answeredDeviceId,
+        answeredVoiceIdentity:
+          call.answeredVoiceIdentity,
+      },
+      ignored: true,
+      code: 'CALL_DEVICE_LOCAL_FAILURE_IGNORED',
+    });
   }
 
   /*
@@ -1108,7 +1189,6 @@ router.patch('/:id/status', asyncHandler(async (req, res) => {
     endReason: endReason ?? undefined,
     answeredDeviceId:
       normalizedStatus === 'ACTIVE' &&
-      call.mode === 'AUDIO' &&
       answeringDevice
         ? answeringDevice.deviceId
         : undefined,


### PR DESCRIPTION
## Summary

- Records the authoritative answering device for video calls.
- Prevents a secondary device's local failure from terminating a shared ringing call.
- Prevents losing devices from terminating the active winning call.
- Validates registered video-answering devices.
- Adds regression coverage for multi-device video authority.

## Root cause

Video calls did not persist an authoritative `answeredDeviceId`, so a secondary or stale device could report a local failure and terminate the canonical call before another device answered.

## Verification

- Calls route tests: 30/30 passed.
- Affected call, device, and push suites: 51/51 passed.
- Physical iPhone cold-start video calls passed twice consecutively with audio.