### PR TITLE
Refresh expiring browser Twilio Voice tokens

### DIFF
--- a/client/src/hooks/__tests__/useTwilioVoice.test.js
+++ b/client/src/hooks/__tests__/useTwilioVoice.test.js
@@ -1,0 +1,179 @@
+import { act, renderHook } from '@testing-library/react';
+import { useTwilioVoice } from '../useTwilioVoice';
+import { fetchVoiceToken } from '@/api/voiceClientApi';
+
+const mockDevices = [];
+
+jest.mock('@/api/voiceClientApi', () => ({
+  fetchVoiceToken: jest.fn(),
+}));
+
+jest.mock('@/utils/safeToast', () => ({
+  toast: {
+    ok: jest.fn(),
+    err: jest.fn(),
+  },
+}));
+
+jest.mock('@twilio/voice-sdk', () => ({
+  Device: jest.fn().mockImplementation(() => {
+    const listeners = new Map();
+
+    const device = {
+      on: jest.fn((event, listener) => {
+        listeners.set(event, listener);
+      }),
+      register: jest.fn(async () => {
+        listeners.get('registered')?.();
+      }),
+      connect: jest.fn(async () => ({
+        on: jest.fn(),
+      })),
+      updateToken: jest.fn(),
+      disconnectAll: jest.fn(),
+      destroy: jest.fn(),
+      emit: (event, ...args) => {
+        listeners.get(event)?.(...args);
+      },
+    };
+
+    mockDevices.push(device);
+    return device;
+  }),
+}));
+
+describe('useTwilioVoice token refresh', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockDevices.length = 0;
+  });
+
+  it('refreshes the existing Device when its token will expire', async () => {
+    fetchVoiceToken
+      .mockResolvedValueOnce({
+        token: 'initial-token',
+        identity: 'user_1',
+      })
+      .mockResolvedValueOnce({
+        token: 'replacement-token',
+        identity: 'user_1',
+      });
+
+    const { result, unmount } = renderHook(() =>
+      useTwilioVoice()
+    );
+
+    await act(async () => {
+      await result.current.startBrowserCall('24', {
+        backendCallId: 823,
+      });
+    });
+
+    const device = mockDevices[0];
+
+    await act(async () => {
+      device.emit('tokenWillExpire');
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(fetchVoiceToken).toHaveBeenCalledTimes(2);
+    expect(device.updateToken).toHaveBeenCalledTimes(1);
+    expect(device.updateToken).toHaveBeenCalledWith(
+      'replacement-token'
+    );
+
+    unmount();
+  });
+
+  it('deduplicates simultaneous token refresh events', async () => {
+    let resolveRefresh;
+
+    fetchVoiceToken
+      .mockResolvedValueOnce({
+        token: 'initial-token',
+        identity: 'user_1',
+      })
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveRefresh = resolve;
+          })
+      );
+
+    const { result, unmount } = renderHook(() =>
+      useTwilioVoice()
+    );
+
+    await act(async () => {
+      await result.current.startBrowserCall('24');
+    });
+
+    const device = mockDevices[0];
+
+    act(() => {
+      device.emit('tokenWillExpire');
+      device.emit('tokenWillExpire');
+    });
+
+    expect(fetchVoiceToken).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      resolveRefresh({
+        token: 'replacement-token',
+        identity: 'user_1',
+      });
+      await Promise.resolve();
+    });
+
+    expect(device.updateToken).toHaveBeenCalledTimes(1);
+    expect(device.updateToken).toHaveBeenCalledWith(
+      'replacement-token'
+    );
+
+    unmount();
+  });
+
+  it('does not update a Device destroyed during refresh', async () => {
+    let resolveRefresh;
+
+    fetchVoiceToken
+      .mockResolvedValueOnce({
+        token: 'initial-token',
+        identity: 'user_1',
+      })
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveRefresh = resolve;
+          })
+      );
+
+    const { result, unmount } = renderHook(() =>
+      useTwilioVoice()
+    );
+
+    await act(async () => {
+      await result.current.startBrowserCall('24');
+    });
+
+    const device = mockDevices[0];
+
+    act(() => {
+      device.emit('tokenWillExpire');
+    });
+
+    unmount();
+
+    await act(async () => {
+      resolveRefresh({
+        token: 'replacement-token',
+        identity: 'user_1',
+      });
+      await Promise.resolve();
+    });
+
+    expect(device.destroy).toHaveBeenCalledTimes(1);
+    expect(device.updateToken).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/hooks/useTwilioVoice.js
+++ b/client/src/hooks/useTwilioVoice.js
@@ -6,6 +6,7 @@ import { toast } from '@/utils/safeToast';
 export function useTwilioVoice() {
   const deviceRef = useRef(null);
   const tokenRef = useRef(null);
+  const tokenRefreshPromiseRef = useRef(null);
 
   const [ready, setReady] = useState(false);
   const [initializing, setInitializing] = useState(false);
@@ -74,6 +75,53 @@ export function useTwilioVoice() {
     });
   }, []);
 
+  const refreshVoiceToken = useCallback(async (device) => {
+    if (tokenRefreshPromiseRef.current) {
+      return tokenRefreshPromiseRef.current;
+    }
+
+    const refreshPromise = (async () => {
+      const { token } = await fetchVoiceToken();
+
+      if (
+        !token ||
+        deviceRef.current !== device
+      ) {
+        return false;
+      }
+
+      device.updateToken(token);
+      tokenRef.current = token;
+
+      console.log('[twilio] Voice token refreshed');
+      return true;
+    })();
+
+    tokenRefreshPromiseRef.current = refreshPromise;
+
+    try {
+      return await refreshPromise;
+    } catch (e) {
+      const msg =
+        e?.response?.data?.error ||
+        e?.response?.data?.message ||
+        e?.message ||
+        'Failed to refresh Twilio Voice token';
+
+      setError(msg);
+      toast.err?.(msg);
+      console.error('[twilio] Voice token refresh failed', e);
+      throw e;
+    } finally {
+      if (
+        tokenRefreshPromiseRef.current ===
+        refreshPromise
+      ) {
+        tokenRefreshPromiseRef.current = null;
+      }
+    }
+  }, []);
+
   const initDevice = useCallback(async () => {
     if (deviceRef.current) return deviceRef.current;
 
@@ -112,6 +160,12 @@ export function useTwilioVoice() {
         attachCallListeners(call);
       });
 
+      device.on('tokenWillExpire', () => {
+        void refreshVoiceToken(device).catch(() => {
+          // State, toast, and logging are handled by refreshVoiceToken.
+        });
+      });
+
       await device.register();
       deviceRef.current = device;
 
@@ -131,7 +185,7 @@ export function useTwilioVoice() {
     } finally {
       setInitializing(false);
     }
-  }, [attachCallListeners]);
+  }, [attachCallListeners, refreshVoiceToken]);
 
   const startBrowserCall = useCallback(
     async (
@@ -221,6 +275,8 @@ export function useTwilioVoice() {
         console.error('[twilio] device destroy error', e);
       } finally {
         deviceRef.current = null;
+        tokenRef.current = null;
+        tokenRefreshPromiseRef.current = null;
       }
     };
   }, []);


### PR DESCRIPTION
## Summary

- Refresh the browser Twilio Voice access token when the SDK emits `tokenWillExpire`.
- Update the existing Twilio Device without interrupting an active call.
- Deduplicate simultaneous token-refresh events.
- Prevent an asynchronously refreshed token from being installed on a destroyed or replaced Device.
- Clear token-refresh state during hook cleanup.
- Add focused regression coverage for successful refresh, refresh deduplication, and Device destruction during refresh.

## Verification

- Focused `useTwilioVoice` tests passed: 3/3.
- Combined `CallContext` and `useTwilioVoice` tests passed: 16/16.
- Production Vite build succeeded.
- Physical-device diagnosis confirmed that reopening the website with a fresh Twilio token restored successful Android calling.
- Call `823` completed successfully with Android as the authoritative winning device and reached terminal `ENDED` state.