### PR TITLE
Polish web call dialogs and overlay

### DIFF
--- a/client/__tests__/ChatView.test.js
+++ b/client/__tests__/ChatView.test.js
@@ -15,6 +15,14 @@ jest.mock('@/utils/toast', () => ({
   },
 }));
 
+
+jest.mock('@mantine/notifications', () => ({
+  __esModule: true,
+  notifications: {
+    show: jest.fn(),
+  },
+}));
+
 /* ---------- Premium / ads ---------- */
 jest.mock('@/hooks/useIsPremium', () => ({
   __esModule: true,
@@ -69,6 +77,15 @@ jest.mock('@/context/UserContext', () => ({
   __esModule: true,
   useUser: () => ({
     setNeedsKeyUnlock: jest.fn(),
+  }),
+}));
+
+jest.mock('@/context/CallContext', () => ({
+  __esModule: true,
+  useCall: () => ({
+    startCall: jest.fn(),
+    active: null,
+    incoming: null,
   }),
 }));
 
@@ -232,7 +249,9 @@ jest.mock('@/lib/sounds.js', () => ({
 }));
 
 /* ---------- Import under test ---------- */
-import ChatView from '../src/components/ChatView.jsx';
+import ChatView, {
+  formatCallStartError,
+} from '../src/components/ChatView.jsx';
 import axiosClient from '@/api/axiosClient';
 import { fetchLatestMessages } from '@/lib/api';
 
@@ -258,6 +277,19 @@ beforeEach(() => {
   });
 
   axiosClient.post.mockResolvedValue({ data: {} });
+});
+
+test('formats an active-call conflict for users', () => {
+  expect(
+    formatCallStartError(
+      new Error(
+        'CALL_ALREADY_IN_PROGRESS'
+      ),
+      'Could not start the call.'
+    )
+  ).toBe(
+    'You already have a call in progress. End it before starting another.'
+  );
 });
 
 test('shows “Select a conversation” when no chatroom', () => {

--- a/client/__tests__/__mocks__/@mantine/core.js
+++ b/client/__tests__/__mocks__/@mantine/core.js
@@ -36,6 +36,9 @@ const ex = {};
 ex.MantineProvider = ({ children }) =>
   React.createElement(React.Fragment, null, children);
 
+ex.Portal = ({ children }) =>
+  React.createElement(React.Fragment, null, children);
+
 ex.Group = passthroughFactory('div');
 ex.Stack = passthroughFactory('div');
 ex.Paper = passthroughFactory('div');

--- a/client/src/components/ChatView.jsx
+++ b/client/src/components/ChatView.jsx
@@ -71,6 +71,7 @@ import { playSound } from '@/lib/sounds.js';
 import useIsPremium from '@/hooks/useIsPremium';
 
 import { useTranslation } from 'react-i18next';
+import { notifications } from '@mantine/notifications';
 
 // 🧱 Ads (render only for Free users)
 import { CardAdWrap } from '@/ads/AdWrappers';
@@ -82,6 +83,19 @@ import { ADS_CONFIG } from '@/ads/config';
 import '@/styles.css';
 
 /* ---------- helpers ---------- */
+export function formatCallStartError(error, fallback) {
+  const code =
+    error?.response?.data?.error ||
+    error?.response?.data?.code ||
+    error?.message;
+
+  if (code === 'CALL_ALREADY_IN_PROGRESS') {
+    return 'You already have a call in progress. End it before starting another.';
+  }
+
+  return code || fallback;
+}
+
 function getMessageTimestampMs(message) {
   const value = message?.createdAt;
   if (!value) return 0;
@@ -619,13 +633,21 @@ export default function ChatView({ chatroom, currentUserId, currentUser }) {
         error
       );
 
-      window.alert(
-        error?.message ||
+      notifications.show({
+        color: 'red',
+        title: t(
+          'calls.unavailable',
+          'Call unavailable'
+        ),
+        message: formatCallStartError(
+          error,
           t(
             'calls.startFailed',
             'Could not start the call.'
           )
-      );
+        ),
+        withBorder: true,
+      });
     }
   }, [
     directCallUnavailable,
@@ -664,13 +686,21 @@ export default function ChatView({ chatroom, currentUserId, currentUser }) {
         error
       );
 
-      window.alert(
-        error?.message ||
+      notifications.show({
+        color: 'red',
+        title: t(
+          'calls.unavailable',
+          'Call unavailable'
+        ),
+        message: formatCallStartError(
+          error,
           t(
             'calls.videoStartFailed',
             'Could not start the video call.'
           )
-      );
+        ),
+        withBorder: true,
+      });
     }
   }, [
     chatroom?.id,

--- a/client/src/components/call/CallScreen.jsx
+++ b/client/src/components/call/CallScreen.jsx
@@ -5,6 +5,7 @@ import {
   Button,
   Group,
   Paper,
+  Portal,
   Stack,
   Text,
   ThemeIcon,
@@ -132,9 +133,10 @@ export default function CallScreen() {
 
   return (
     <>
-      <Box
-        style={{
-          position: 'fixed',
+      <Portal>
+        <Box
+          style={{
+            position: 'fixed',
           inset: 0,
           zIndex: 1000,
           background:
@@ -335,7 +337,8 @@ export default function CallScreen() {
             </Paper>
           )}
         </Box>
-      </Box>
+        </Box>
+      </Portal>
 
       <AddCallParticipantModal
         opened={addOpen}

--- a/client/src/components/routes/Dialer.jsx
+++ b/client/src/components/routes/Dialer.jsx
@@ -14,6 +14,7 @@ import {
   ThemeIcon,
   Badge,
   ActionIcon,
+  Modal,
 } from '@mantine/core';
 import {
   PhoneOutgoing,
@@ -118,6 +119,8 @@ export default function Dialer() {
   const [history, setHistory] = useState([]);
   const [historyLoading, setHistoryLoading] = useState(true);
   const [historyError, setHistoryError] = useState('');
+  const [deleteCallId, setDeleteCallId] = useState(null);
+  const [deletingCallId, setDeletingCallId] = useState(null);
 
   const { startCall, pending: appCallPending } = useCall();
   const { placeCall, loading: pstnLoading, error: pstnError } = usePstnCall();
@@ -234,17 +237,20 @@ export default function Dialer() {
     }
   };
 
-  const handleDelete = async (callId) => {
-    if (
-      !window.confirm(
-        t('dialer.deleteConfirm', 'Delete this call from recents?')
-      )
-    )
-      return;
+  const closeDeleteModal = () => {
+    if (deletingCallId != null) return;
+    setDeleteCallId(null);
+  };
+
+  const handleDelete = async () => {
+    const callId = deleteCallId;
+    if (callId == null) return;
 
     try {
+      setDeletingCallId(callId);
       await axiosClient.delete(`/calls/${callId}`);
       setHistory((prev) => prev.filter((item) => item.id !== callId));
+      setDeleteCallId(null);
     } catch (e) {
       console.error(t('dialer.deleteFailedLog', 'Failed to delete call'), e);
       setHistoryError(
@@ -252,6 +258,8 @@ export default function Dialer() {
           e?.message ||
           t('dialer.deleteFailed', 'Could not delete call.')
       );
+    } finally {
+      setDeletingCallId(null);
     }
   };
 
@@ -505,7 +513,7 @@ export default function Dialer() {
                             color="red"
                             radius="xl"
                             size={32}
-                            onClick={() => handleDelete(item.id)}
+                            onClick={() => setDeleteCallId(item.id)}
                             aria-label={`Delete call with ${otherPartyName}`}
                           >
                             <Trash2 size={15} />
@@ -520,6 +528,40 @@ export default function Dialer() {
           })}
         </Stack>
       )}
+
+      <Modal
+        opened={deleteCallId != null}
+        onClose={closeDeleteModal}
+        title={t('dialer.deleteTitle', 'Delete recent call?')}
+        centered
+      >
+        <Stack gap="md">
+          <Text size="sm">
+            {t(
+              'dialer.deleteConfirm',
+              'This call will be removed from your recent calls.'
+            )}
+          </Text>
+
+          <Group justify="flex-end">
+            <Button
+              variant="default"
+              onClick={closeDeleteModal}
+              disabled={deletingCallId != null}
+            >
+              {t('common.cancel', 'Cancel')}
+            </Button>
+
+            <Button
+              color="red"
+              onClick={handleDelete}
+              loading={deletingCallId != null}
+            >
+              {t('common.delete', 'Delete')}
+            </Button>
+          </Group>
+        </Stack>
+      </Modal>
     </Box>
   );
 }

--- a/client/src/components/routes/__tests__/Dialer.test.js
+++ b/client/src/components/routes/__tests__/Dialer.test.js
@@ -77,6 +77,7 @@ jest.mock('lucide-react', () => {
     Voicemail: Icon,
     Phone: Icon,
     Trash2: Icon,
+    Video: Icon,
   };
 });
 
@@ -193,6 +194,24 @@ jest.mock('@mantine/core', () => {
     </button>
   );
 
+  const Modal = ({
+    opened,
+    title,
+    children,
+  }) => {
+    if (!opened) return null;
+
+    return (
+      <div
+        role="dialog"
+        aria-label={title}
+      >
+        <h2>{title}</h2>
+        {children}
+      </div>
+    );
+  };
+
   return {
     __esModule: true,
     Box,
@@ -207,9 +226,11 @@ jest.mock('@mantine/core', () => {
     ThemeIcon,
     Badge,
     ActionIcon,
+    Modal,
   };
 });
 
+import axiosClient from '@/api/axiosClient';
 import { getCallHistory } from '@/api/calls';
 import Dialer from '../Dialer';
 
@@ -312,5 +333,121 @@ describe('Dialer', () => {
     await user.click(screen.getByRole('button', { name: 'Call' }));
 
     expect(mockPlaceCall).toHaveBeenCalledWith('5551234567');
+  });
+
+  it('cancels recent-call deletion from the styled modal', async () => {
+    const user = userEvent.setup();
+
+    getCallHistory.mockResolvedValueOnce([
+      {
+        id: 42,
+        callerId: 1,
+        callee: {
+          id: 2,
+          username: 'Bob',
+        },
+        mode: 'AUDIO',
+        status: 'ENDED',
+        createdAt: '2026-08-14T00:00:00.000Z',
+      },
+    ]);
+
+    render(<Dialer />);
+
+    await user.click(
+      await screen.findByRole(
+        'button',
+        {
+          name: 'Delete call with Bob',
+        }
+      )
+    );
+
+    expect(
+      screen.getByRole(
+        'dialog',
+        {
+          name: 'Delete recent call?',
+        }
+      )
+    ).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole(
+        'button',
+        {
+          name: 'Cancel',
+        }
+      )
+    );
+
+    expect(
+      axiosClient.delete
+    ).not.toHaveBeenCalled();
+
+    expect(
+      screen.queryByRole(
+        'dialog',
+        {
+          name: 'Delete recent call?',
+        }
+      )
+    ).not.toBeInTheDocument();
+  });
+
+  it('deletes a recent call after styled confirmation', async () => {
+    const user = userEvent.setup();
+
+    getCallHistory.mockResolvedValueOnce([
+      {
+        id: 42,
+        callerId: 1,
+        callee: {
+          id: 2,
+          username: 'Bob',
+        },
+        mode: 'AUDIO',
+        status: 'ENDED',
+        createdAt: '2026-08-14T00:00:00.000Z',
+      },
+    ]);
+
+    axiosClient.delete.mockResolvedValueOnce({
+      data: {
+        ok: true,
+      },
+    });
+
+    render(<Dialer />);
+
+    await user.click(
+      await screen.findByRole(
+        'button',
+        {
+          name: 'Delete call with Bob',
+        }
+      )
+    );
+
+    await user.click(
+      screen.getByRole(
+        'button',
+        {
+          name: 'Delete',
+        }
+      )
+    );
+
+    await waitFor(() => {
+      expect(
+        axiosClient.delete
+      ).toHaveBeenCalledWith(
+        '/calls/42'
+      );
+    });
+
+    expect(
+      screen.queryByText('Bob')
+    ).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

- Replace raw call-start browser alerts with styled site notifications.
- Translate `CALL_ALREADY_IN_PROGRESS` into a clear user-facing message.
- Replace the native recent-call deletion confirmation with a styled modal.
- Preserve cancellation, loading, error, and successful deletion behavior.
- Render the active call overlay through a viewport-level portal so video calls remain properly centered.
- Add focused regression coverage for call-error formatting and recent-call deletion.

## Verification

- `ChatView`, `Dialer`, and `CallScreen` focused suites passed: 15/15 tests.
- Production Vite build passed.
- `git diff --check` and staged diff checks passed.