### PR TITLE
Fix incoming web video acceptance

### DIFF
--- a/client/__tests__/IncomingCallModal.test.js
+++ b/client/__tests__/IncomingCallModal.test.js
@@ -1,66 +1,214 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
 
-// ----- Controlled test doubles (allowed in mock factory because names start with "mock") -----
 let mockIncoming = {
   mode: 'VIDEO',
-  fromUser: { username: 'alice' },
+  fromUser: {
+    username: 'alice',
+  },
 };
+
 const mockAccept = jest.fn();
 const mockReject = jest.fn();
+const mockShowNotification =
+  jest.fn();
 
-// Mock the exact modules the component imports
-jest.mock('@/context/CallContext', () => ({
-  __esModule: true,
-  useCall: () => ({
-    incoming: mockIncoming,
-    acceptCall: mockAccept,
-    rejectCall: mockReject,
-  }),
-}));
+jest.mock(
+  '@/context/CallContext',
+  () => ({
+    __esModule: true,
+    useCall: () => ({
+      incoming: mockIncoming,
+      acceptCall: mockAccept,
+      rejectCall: mockReject,
+    }),
+  })
+);
 
-jest.mock('@/utils/safeToast', () => ({
-  __esModule: true,
-  toast: {
-    ok: jest.fn(),
-    info: jest.fn(),
-    err: jest.fn(),
-  },
-}));
+jest.mock(
+  '@mantine/notifications',
+  () => ({
+    __esModule: true,
+    notifications: {
+      show: (...args) =>
+        mockShowNotification(
+          ...args
+        ),
+    },
+  })
+);
 
-// SUT
 import IncomingCallModal from '@/components/IncomingCallModal';
 
 describe('IncomingCallModal', () => {
   beforeEach(() => {
-    mockAccept.mockClear();
-    mockReject.mockClear();
+    mockIncoming = {
+      mode: 'VIDEO',
+      fromUser: {
+        username: 'alice',
+      },
+    };
+
+    mockAccept.mockReset();
+    mockReject.mockReset();
+    mockShowNotification
+      .mockReset();
+
+    mockAccept
+      .mockResolvedValue(undefined);
+
+    mockReject
+      .mockResolvedValue(undefined);
   });
 
-  test('renders and wires Accept/Reject', () => {
-    // incoming call present
-    mockIncoming = { mode: 'VIDEO', fromUser: { username: 'alice' } };
+  test(
+    'renders styled controls and wires acceptance and rejection',
+    async () => {
+      render(<IncomingCallModal />);
 
-    render(<IncomingCallModal />);
+      expect(
+        screen.getByText(
+          'Incoming video call'
+        )
+      ).toBeInTheDocument();
 
-    expect(screen.getByText(/incoming/i)).toBeInTheDocument();
+      expect(
+        screen.getByText('alice')
+      ).toBeInTheDocument();
 
-    const acceptBtn  = screen.getByRole('button', { name: /accept|answer/i });
-    const declineBtn = screen.getByRole('button', { name: /decline|reject|deny/i });
+      const acceptButton =
+        screen.getByRole(
+          'button',
+          {
+            name: /accept/i,
+          }
+        );
 
-    fireEvent.click(acceptBtn);
-    expect(mockAccept).toHaveBeenCalled();
+      fireEvent.click(
+        acceptButton
+      );
 
-    fireEvent.click(declineBtn);
-    expect(mockReject).toHaveBeenCalled();
-  });
+      await waitFor(() => {
+        expect(
+          mockAccept
+        ).toHaveBeenCalledTimes(1);
+      });
 
-  test('renders nothing if no incoming call', () => {
-    // no incoming call
-    mockIncoming = null;
+      await waitFor(() => {
+        expect(
+          acceptButton
+        ).not.toBeDisabled();
+      });
 
-    const { queryByText, queryByRole } = render(<IncomingCallModal />);
-    expect(queryByText(/incoming/i)).toBeNull();
-    expect(queryByRole('button', { name: /accept|answer/i })).toBeNull();
-    expect(queryByRole('button', { name: /decline|reject|deny/i })).toBeNull();
-  });
+      fireEvent.click(
+        screen.getByRole(
+          'button',
+          {
+            name: /decline/i,
+          }
+        )
+      );
+
+      await waitFor(() => {
+        expect(
+          mockReject
+        ).toHaveBeenCalledTimes(1);
+      });
+    }
+  );
+
+  test(
+    'keeps hook order stable when a call appears',
+    () => {
+      mockIncoming = null;
+
+      const { rerender } =
+        render(
+          <IncomingCallModal />
+        );
+
+      expect(
+        screen.queryByText(
+          'Incoming video call'
+        )
+      ).not.toBeInTheDocument();
+
+      mockIncoming = {
+        mode: 'VIDEO',
+        callerName: 'Reviewer',
+      };
+
+      rerender(
+        <IncomingCallModal />
+      );
+
+      expect(
+        screen.getByText(
+          'Incoming video call'
+        )
+      ).toBeInTheDocument();
+
+      expect(
+        screen.getByText('Reviewer')
+      ).toBeInTheDocument();
+    }
+  );
+
+  test(
+    'shows a visible acceptance error',
+    async () => {
+      mockAccept
+        .mockRejectedValueOnce(
+          new Error(
+            'Video room unavailable'
+          )
+        );
+
+      render(<IncomingCallModal />);
+
+      fireEvent.click(
+        screen.getByRole(
+          'button',
+          {
+            name: /accept/i,
+          }
+        )
+      );
+
+      await waitFor(() => {
+        expect(
+          mockShowNotification
+        ).toHaveBeenCalledWith(
+          expect.objectContaining({
+            color: 'red',
+            title:
+              'Could not answer call',
+            message:
+              'Video room unavailable',
+          })
+        );
+      });
+    }
+  );
+
+  test(
+    'renders nothing without an incoming call',
+    () => {
+      mockIncoming = null;
+
+      render(
+        <IncomingCallModal />
+      );
+
+      expect(
+        screen.queryByText(
+          /incoming (video|audio) call/i
+        )
+      ).not.toBeInTheDocument();
+    }
+  );
 });

--- a/client/src/components/IncomingCallModal.jsx
+++ b/client/src/components/IncomingCallModal.jsx
@@ -1,104 +1,178 @@
 import { useState } from 'react';
+import {
+  Button,
+  Group,
+  Modal,
+  Stack,
+  Text,
+} from '@mantine/core';
+import {
+  notifications,
+} from '@mantine/notifications';
 import { useCall } from '../context/CallContext';
-import { toast } from '../utils/safeToast';
 
 export default function IncomingCallModal() {
   const call = useCall();
 
-  if (!call || !call.incoming) return null;
+  /*
+   * Keep hooks unconditional so an incoming call can safely
+   * appear after the component's initial render.
+   */
+  const [pending, setPending] =
+    useState(null);
+
+  const incoming =
+    call?.incoming;
+
+  if (!call || !incoming) {
+    return null;
+  }
 
   const {
-    incoming,
     acceptCall,
     rejectCall,
-    accept,   // support alias
-    reject,   // support alias
-    onAccept, // support alias/callback
-    onReject, // support alias/callback
+    accept,
+    reject,
+    onAccept,
+    onReject,
   } = call;
 
-  const doAccept = acceptCall || accept || onAccept;
-  const doReject = rejectCall || reject || onReject;
+  const doAccept =
+    acceptCall ||
+    accept ||
+    onAccept;
 
-  // 'accept' | 'reject' | null
-  const [pending, setPending] = useState(null);
+  const doReject =
+    rejectCall ||
+    reject ||
+    onReject;
+
+  const callerName =
+    incoming.callerName ||
+    incoming.fromUser?.displayName ||
+    incoming.fromUser?.name ||
+    incoming.fromUser?.username ||
+    (
+      incoming.fromUser?.id
+        ? `User ${incoming.fromUser.id}`
+        : 'Unknown caller'
+    );
+
+  const isVideo =
+    incoming.mode === 'VIDEO';
 
   const handleAccept = async () => {
-    // Only block re-clicking Accept while Accept is pending
-    if (pending === 'accept') return;
+    if (pending != null) return;
+
     setPending('accept');
+
     try {
       await doAccept?.();
-      toast.ok('Call started');
-    } catch (err) {
-      const msg =
-        err?.response?.data?.message ||
-        err?.message ||
-        'Failed to accept call';
-      toast.err(msg);
+    } catch (error) {
+      notifications.show({
+        color: 'red',
+        title:
+          'Could not answer call',
+        message:
+          error?.response?.data
+            ?.message ||
+          error?.message ||
+          'Failed to accept call.',
+        withBorder: true,
+      });
     } finally {
       setPending(null);
     }
   };
 
   const handleReject = async () => {
-    // Only block re-clicking Reject while Reject is pending
-    if (pending === 'reject') return;
+    if (pending != null) return;
+
     setPending('reject');
+
     try {
       await doReject?.();
-      toast.info('Call declined');
-    } catch (err) {
-      const msg =
-        err?.response?.data?.message ||
-        err?.message ||
-        'Failed to decline call';
-      toast.err(msg);
+    } catch (error) {
+      notifications.show({
+        color: 'red',
+        title:
+          'Could not decline call',
+        message:
+          error?.response?.data
+            ?.message ||
+          error?.message ||
+          'Failed to decline call.',
+        withBorder: true,
+      });
     } finally {
       setPending(null);
     }
   };
 
   return (
-    <div
-      className="fixed inset-0 bg-black/50 flex items-center justify-center z-50"
-      role="dialog"
-      aria-modal="true"
-      aria-label="Incoming call"
+    <Modal
+      opened
+      onClose={() => {}}
+      title={
+        isVideo
+          ? 'Incoming video call'
+          : 'Incoming audio call'
+      }
+      centered
+      withCloseButton={false}
+      closeOnClickOutside={false}
+      closeOnEscape={false}
+      overlayProps={{
+        backgroundOpacity: 0.72,
+        blur: 4,
+      }}
     >
-      <div className="bg-white rounded-xl p-6 w-[360px] shadow-xl">
-        <h3 className="text-lg font-semibold mb-1">
-          Incoming {incoming.mode === 'VIDEO' ? 'Video' : 'Audio'} Call
-        </h3>
-        <p className="text-sm text-gray-600 mb-4">
-          from{' '}
-          {incoming.fromUser?.name ??
-            incoming.fromUser?.username ??
-            (incoming.fromUser?.id
-              ? `User ${incoming.fromUser.id}`
-              : 'Unknown caller')}
-        </p>
-        <div className="flex gap-3 justify-end">
-          <button
+      <Stack gap="lg">
+        <Stack gap={4}>
+          <Text size="sm" c="dimmed">
+            Incoming call from
+          </Text>
+
+          <Text fw={700} size="lg">
+            {callerName}
+          </Text>
+
+          <Text size="sm" c="dimmed">
+            {isVideo
+              ? 'Answer to join the video call.'
+              : 'Answer to join the audio call.'}
+          </Text>
+        </Stack>
+
+        <Group
+          justify="flex-end"
+          gap="sm"
+        >
+          <Button
+            variant="default"
             onClick={handleReject}
-            // only disable the reject button while reject is pending
-            disabled={pending === 'reject'}
-            className="px-4 py-2 rounded-lg bg-gray-200 disabled:opacity-60"
+            loading={
+              pending === 'reject'
+            }
+            disabled={pending != null}
             data-testid="decline"
           >
-            {pending === 'reject' ? 'Declining…' : 'Decline'}
-          </button>
-          <button
+            Decline
+          </Button>
+
+          <Button
+            color="yellow"
             onClick={handleAccept}
-            // only disable the accept button while accept is pending
-            disabled={pending === 'accept'}
-            className="px-4 py-2 rounded-lg bg-blue-600 text-white disabled:opacity-60"
+            loading={
+              pending === 'accept'
+            }
+            disabled={pending != null}
             data-testid="accept"
           >
-            {pending === 'accept' ? 'Connecting…' : 'Accept'}
-          </button>
-        </div>
-      </div>
-    </div>
+            Accept
+          </Button>
+        </Group>
+      </Stack>
+    </Modal>
   );
 }

--- a/client/src/context/CallContext.jsx
+++ b/client/src/context/CallContext.jsx
@@ -749,6 +749,136 @@ return data;
       return;
     }
 
+    /*
+     * Native clients originate canonical video calls through a
+     * Twilio Video room and therefore send no legacy SDP offer.
+     */
+    if (
+      mode === 'VIDEO' &&
+      !offer
+    ) {
+      const roomName =
+        incoming.roomName ||
+        `call_${callId}`;
+
+      answeringCallIdRef.current =
+        callId;
+
+      setPending(true);
+      setStatus('Connecting…');
+
+      let response;
+
+      try {
+        response = await fetch(
+          `${API_BASE}/calls/answer`,
+          {
+            method: 'POST',
+            credentials: 'include',
+            headers: {
+              'Content-Type':
+                'application/json',
+            },
+            body: JSON.stringify({
+              callId,
+              answer: null,
+            }),
+          }
+        );
+      } catch (error) {
+        answeringCallIdRef.current =
+          null;
+
+        cleanup();
+        throw error;
+      }
+
+      const responseData =
+        await response
+          .json()
+          .catch(() => ({}));
+
+      if (response.ok === false) {
+        answeringCallIdRef.current =
+          null;
+
+        cleanup();
+
+        if (
+          response.status === 409 &&
+          responseData?.code ===
+            'CALL_ANSWERED_ELSEWHERE'
+        ) {
+          return;
+        }
+
+        const error =
+          new Error(
+            responseData?.error ||
+            'Could not answer this call.'
+          );
+
+        error.code =
+          responseData?.code ||
+          null;
+
+        throw error;
+      }
+
+      try {
+        await connectTwilioVideo({
+          callId,
+          roomName,
+        });
+      } catch (error) {
+        answeringCallIdRef.current =
+          null;
+
+        await fetch(
+          `${API_BASE}/calls/end`,
+          {
+            method: 'POST',
+            credentials: 'include',
+            headers: {
+              'Content-Type':
+                'application/json',
+            },
+            body: JSON.stringify({
+              callId,
+              reason:
+                'media_connect_failed',
+            }),
+          }
+        ).catch(() => {});
+
+        cleanup();
+        throw error;
+      }
+
+      const nextActive = {
+        callId,
+        peerId: fromUser?.id,
+        mode: 'VIDEO',
+        peerName,
+        roomName,
+        mediaTransport:
+          'twilio-video',
+      };
+
+      activeRef.current =
+        nextActive;
+
+      setActive(nextActive);
+
+      answeringCallIdRef.current =
+        null;
+
+      setIncoming(null);
+      setPending(false);
+
+      return;
+    }
+
     const pc = await createPeer({ callId, peerId: fromUser?.id });
     const local = await navigator.mediaDevices.getUserMedia({ video: mode === 'VIDEO', audio: true });
     localStreamRef.current = local;

--- a/client/src/context/__tests__/CallContext.test.js
+++ b/client/src/context/__tests__/CallContext.test.js
@@ -521,6 +521,159 @@ test('startCall routes app audio through Twilio Voice with the backend call ID',
   });
 });
 
+test(
+  'acceptCall claims and joins an incoming canonical Twilio Video room',
+  async () => {
+    renderWithProvider();
+
+    act(() => {
+      socketMock.emit(
+        'video:incoming',
+        {
+          callId:
+            'incoming-video-room-1',
+          roomName:
+            'call_incoming-video-room-1',
+          fromUser: {
+            id: 456,
+            displayName:
+              'Reviewer',
+          },
+          mode: 'VIDEO',
+          offer: null,
+        }
+      );
+    });
+
+    await act(async () => {
+      await ctxRef.acceptCall();
+    });
+
+    const answerCall =
+      fetchMock.mock.calls.find(
+        ([url]) =>
+          url.includes(
+            '/calls/answer'
+          )
+      );
+
+    expect(answerCall)
+      .toBeTruthy();
+
+    expect(
+      JSON.parse(
+        answerCall[1].body
+      )
+    ).toEqual({
+      callId:
+        'incoming-video-room-1',
+      answer: null,
+    });
+
+    expect(
+      mockJoinRoom
+    ).toHaveBeenCalledWith({
+      identity: '7',
+      room:
+        'call_incoming-video-room-1',
+    });
+
+    expect(
+      navigator.mediaDevices
+        .getUserMedia
+    ).not.toHaveBeenCalled();
+
+    expect(
+      ctxRef.active
+    ).toMatchObject({
+      callId:
+        'incoming-video-room-1',
+      peerId: 456,
+      mode: 'VIDEO',
+      peerName: 'Reviewer',
+      roomName:
+        'call_incoming-video-room-1',
+      mediaTransport:
+        'twilio-video',
+    });
+
+    expect(
+      ctxRef.incoming
+    ).toBe(null);
+  }
+);
+
+test(
+  'acceptCall ends a claimed video call when its Twilio room cannot connect',
+  async () => {
+    renderWithProvider();
+
+    mockJoinRoom
+      .mockRejectedValueOnce(
+        new Error(
+          'Video room unavailable'
+        )
+      );
+
+    act(() => {
+      socketMock.emit(
+        'video:incoming',
+        {
+          callId:
+            'incoming-video-room-2',
+          roomName:
+            'call_incoming-video-room-2',
+          fromUser: {
+            id: 456,
+          },
+          mode: 'VIDEO',
+          offer: null,
+        }
+      );
+    });
+
+    let caughtError = null;
+
+    await act(async () => {
+      try {
+        await ctxRef.acceptCall();
+      } catch (error) {
+        caughtError = error;
+      }
+    });
+
+    expect(
+      caughtError?.message
+    ).toBe(
+      'Video room unavailable'
+    );
+
+    const endCall =
+      fetchMock.mock.calls.find(
+        ([url]) =>
+          url.includes('/calls/end')
+      );
+
+    expect(endCall)
+      .toBeTruthy();
+
+    expect(
+      JSON.parse(
+        endCall[1].body
+      )
+    ).toEqual({
+      callId:
+        'incoming-video-room-2',
+      reason:
+        'media_connect_failed',
+    });
+
+    expect(
+      ctxRef.active
+    ).toBe(null);
+  }
+);
+
 test('acceptCall consumes incoming offer, sends answer, sets active and clears incoming', async () => {
     renderWithProvider();
 


### PR DESCRIPTION
## Summary

- Route canonical incoming video calls without SDP offers through Twilio Video.
- Claim the backend call before joining the supplied Twilio room.
- Preserve the legacy SDP/WebRTC acceptance path.
- End an already-claimed call if its Twilio room cannot connect.
- Replace the unstyled incoming-call prompt with a centered Mantine modal.
- Show visible acceptance and rejection errors.
- Keep React hook ordering stable when an incoming call appears.
- Add focused incoming-call and room-reconciliation regression tests.

## Verification

- `CallContext`, `IncomingCallModal`, and `CallScreen` focused suites passed: 23/23 tests.
- Production Vite build passed.
- `git diff --check` and staged diff checks passed.