### PR TITLE
Attach delayed Twilio video streams

### DIFF
--- a/client/src/components/call/CallScreen.jsx
+++ b/client/src/components/call/CallScreen.jsx
@@ -51,15 +51,60 @@ export default function CallScreen() {
       return undefined;
     }
 
-    const timer = setInterval(() => {
-      const tracks = remoteStream?.current?.getVideoTracks?.() || [];
-      const hasLiveVideo = tracks.some((track) => track.readyState === 'live');
+    const synchronizeVideoStreams = () => {
+      const local = localStream?.current;
+      const remote = remoteStream?.current;
+
+      /*
+       * Twilio adds tracks by mutating these stable refs. That
+       * mutation does not trigger React to rerun the attachment
+       * effects above, so synchronize the DOM video elements
+       * while checking media readiness.
+       */
+      if (
+        localRef.current &&
+        local &&
+        localRef.current.srcObject !== local
+      ) {
+        localRef.current.srcObject = local;
+      }
+
+      if (
+        remoteRef.current &&
+        remote &&
+        remoteRef.current.srcObject !== remote
+      ) {
+        remoteRef.current.srcObject = remote;
+      }
+
+      const tracks =
+        remote?.getVideoTracks?.() || [];
+
+      const hasLiveVideo =
+        tracks.some(
+          (track) =>
+            track.readyState === 'live'
+        );
 
       setHasRemoteVideo(hasLiveVideo);
-    }, 500);
+    };
 
-    return () => clearInterval(timer);
-  }, [active?.callId, active?.mode, remoteStream]);
+    synchronizeVideoStreams();
+
+    const timer =
+      setInterval(
+        synchronizeVideoStreams,
+        500
+      );
+
+    return () =>
+      clearInterval(timer);
+  }, [
+    active?.callId,
+    active?.mode,
+    localStream,
+    remoteStream,
+  ]);
 
   if (!active) return null;
 

--- a/client/src/components/call/__tests__/CallScreen.test.js
+++ b/client/src/components/call/__tests__/CallScreen.test.js
@@ -1,4 +1,5 @@
 import {
+  act,
   render,
   screen,
   fireEvent,
@@ -291,4 +292,95 @@ describe('CallScreen', () => {
       newRemoteRef.current
     );
   });
+  test(
+    'attaches Twilio streams that arrive through stable refs',
+    () => {
+      jest.useFakeTimers();
+
+      let unmount = () => {};
+
+      try {
+        const localRef = {
+          current: null,
+        };
+
+        const remoteRef = {
+          current: null,
+        };
+
+        mockUseCall = () => ({
+          active: {
+            callId: 'late-stream-call',
+            mode: 'VIDEO',
+            mediaTransport:
+              'twilio-video',
+          },
+          status: 'connected',
+          localStream: localRef,
+          remoteStream: remoteRef,
+          participants: [],
+          addParticipant: undefined,
+          me: {
+            id: 1,
+          },
+          endCall: jest.fn(),
+        });
+
+        const rendered = render(
+          <CallScreen />
+        );
+
+        unmount = rendered.unmount;
+
+        const [
+          remoteVideo,
+          localVideo,
+        ] =
+          rendered.container
+            .querySelectorAll('video');
+
+        expect(
+          remoteVideo.srcObject
+        ).toBeUndefined();
+
+        expect(
+          localVideo.srcObject
+        ).toBeUndefined();
+
+        const lateLocal =
+          makeStream('late-local');
+
+        const lateRemote =
+          makeStream('late-remote');
+
+        act(() => {
+          /*
+           * Match Twilio's real behavior: mutate .current
+           * without replacing either React ref object.
+           */
+          localRef.current =
+            lateLocal;
+
+          remoteRef.current =
+            lateRemote;
+
+          jest.advanceTimersByTime(
+            500
+          );
+        });
+
+        expect(
+          localVideo.srcObject
+        ).toBe(lateLocal);
+
+        expect(
+          remoteVideo.srcObject
+        ).toBe(lateRemote);
+      } finally {
+        unmount();
+        jest.useRealTimers();
+      }
+    }
+  );
+
 });


### PR DESCRIPTION
## Summary

* Synchronize active video elements with Twilio media streams that arrive after the call screen renders.
* Handle Twilio’s stable-ref mutation behavior without requiring a React rerender.
* Attach both local and remote streams during the existing video-readiness check.
* Preserve the current video layout, call controls, and call-signaling behavior.
* Add regression coverage for local and remote streams arriving through unchanged React ref objects.

## Verification

* `CallScreen`, `CallContext`, and `IncomingCallModal` focused suites passed: 24/24 tests.
* Production Vite build passed.
* `git diff --check` and staged diff checks passed.
* Local production-API testing reached the expected CSRF boundary; production physical verification remains pending deployment.
