### PR TITLE
Fix incoming web audio acceptance

### DIFF
--- a/client/src/context/CallContext.jsx
+++ b/client/src/context/CallContext.jsx
@@ -97,6 +97,20 @@ const twilioVideoRoomRef = useRef(null);
     twilioVoice.callStatus,
     twilioVoice.error,
   ]);
+
+  /*
+   * Keep the browser Twilio Voice Device registered so native
+   * callers can deliver their SDK invitation before the user
+   * presses Accept.
+   */
+  useEffect(() => {
+    void twilioVoice
+      .initialize()
+      .catch(() => {
+        // The hook records and reports initialization errors.
+      });
+  }, [twilioVoice.initialize]);
+
   const [participants, setParticipants] = useState([]);
 
   // Keep local & remote streams for UI
@@ -750,6 +764,140 @@ return data;
     }
 
     /*
+     * Native clients originate canonical audio calls through
+     * Twilio Voice and therefore send no legacy SDP offer.
+     */
+    if (
+      mode === 'AUDIO' &&
+      !offer
+    ) {
+      answeringCallIdRef.current =
+        callId;
+
+      setPending(true);
+      setStatus('Connecting…');
+
+      try {
+        await twilioVoice
+          .initialize();
+      } catch (error) {
+        answeringCallIdRef.current =
+          null;
+
+        cleanup();
+        throw error;
+      }
+
+      let response;
+
+      try {
+        response = await fetch(
+          `${API_BASE}/calls/answer`,
+          {
+            method: 'POST',
+            credentials: 'include',
+            headers: {
+              'Content-Type':
+                'application/json',
+            },
+            body: JSON.stringify({
+              callId,
+              answer: null,
+            }),
+          }
+        );
+      } catch (error) {
+        answeringCallIdRef.current =
+          null;
+
+        cleanup();
+        throw error;
+      }
+
+      const responseData =
+        await response
+          .json()
+          .catch(() => ({}));
+
+      if (response.ok === false) {
+        answeringCallIdRef.current =
+          null;
+
+        cleanup();
+
+        if (
+          response.status === 409 &&
+          responseData?.code ===
+            'CALL_ANSWERED_ELSEWHERE'
+        ) {
+          return;
+        }
+
+        const error =
+          new Error(
+            responseData?.error ||
+            'Could not answer this call.'
+          );
+
+        error.code =
+          responseData?.code ||
+          null;
+
+        throw error;
+      }
+
+      try {
+        await twilioVoice
+          .acceptIncomingCall();
+      } catch (error) {
+        answeringCallIdRef.current =
+          null;
+
+        await fetch(
+          `${API_BASE}/calls/end`,
+          {
+            method: 'POST',
+            credentials: 'include',
+            headers: {
+              'Content-Type':
+                'application/json',
+            },
+            body: JSON.stringify({
+              callId,
+              reason:
+                'media_connect_failed',
+            }),
+          }
+        ).catch(() => {});
+
+        cleanup();
+        throw error;
+      }
+
+      const nextActive = {
+        callId,
+        peerId: fromUser?.id,
+        mode: 'AUDIO',
+        peerName,
+        mediaTransport:
+          'twilio-voice',
+      };
+
+      activeRef.current =
+        nextActive;
+
+      setActive(nextActive);
+
+      answeringCallIdRef.current =
+        null;
+
+      setIncoming(null);
+      setPending(false);
+
+      return;
+    }
+
+    /*
      * Native clients originate canonical video calls through a
      * Twilio Video room and therefore send no legacy SDP offer.
      */
@@ -1042,6 +1190,17 @@ async function onParticipantOffer({ callId, fromUser, offer }) {
 
   async function rejectCall() {
     if (!incoming) return;
+
+    const rejectsTwilioVoice =
+      !incoming.isParticipantInvite &&
+      incoming.mode?.toUpperCase() ===
+        'AUDIO' &&
+      !incoming.offer;
+
+    if (rejectsTwilioVoice) {
+      twilioVoice
+        .rejectIncomingCall();
+    }
 
     const url = incoming.isParticipantInvite
       ? `${API_BASE}/calls/${incoming.callId}/decline-participant`

--- a/client/src/context/__tests__/CallContext.test.js
+++ b/client/src/context/__tests__/CallContext.test.js
@@ -3,6 +3,9 @@ import { render, act } from '@testing-library/react';
 import { CallProvider, useCall } from '@/context/CallContext';
 
 const mockStartBrowserCall = jest.fn();
+const mockInitializeVoice = jest.fn();
+const mockAcceptIncomingVoiceCall = jest.fn();
+const mockRejectIncomingVoiceCall = jest.fn();
 const mockTwilioHangup = jest.fn();
 
 const mockTwilioVoiceState = {
@@ -12,8 +15,14 @@ const mockTwilioVoiceState = {
   callStatus: 'idle',
   error: null,
   currentCall: null,
+  initialize:
+    mockInitializeVoice,
   startBrowserCall:
     mockStartBrowserCall,
+  acceptIncomingCall:
+    mockAcceptIncomingVoiceCall,
+  rejectIncomingCall:
+    mockRejectIncomingVoiceCall,
   hangup: mockTwilioHangup,
 };
 
@@ -290,9 +299,20 @@ mockVideoRoom
 
   mockStartBrowserCall.mockReset();
   mockStartBrowserCall.mockResolvedValue({});
+
+  mockInitializeVoice.mockReset();
+  mockInitializeVoice.mockResolvedValue({});
+
+  mockAcceptIncomingVoiceCall.mockReset();
+  mockAcceptIncomingVoiceCall.mockResolvedValue({});
+
+  mockRejectIncomingVoiceCall.mockReset();
+  mockRejectIncomingVoiceCall.mockResolvedValue({});
+
   mockTwilioHangup.mockReset();
   mockTwilioVoiceState.callStatus = 'idle';
   mockTwilioVoiceState.error = null;
+  mockTwilioVoiceState.currentCall = null;
 
   fetchMock.mockClear();
   navigator.mediaDevices.getUserMedia.mockClear();
@@ -520,6 +540,215 @@ test('startCall routes app audio through Twilio Voice with the backend call ID',
     mediaTransport: 'twilio-voice',
   });
 });
+
+test(
+  'acceptCall claims and accepts an incoming canonical Twilio Voice call',
+  async () => {
+    renderWithProvider();
+
+    act(() => {
+      socketMock.emit(
+        'call:incoming',
+        {
+          callId:
+            'incoming-audio-1',
+          fromUser: {
+            id: 456,
+            displayName:
+              'Reviewer',
+          },
+          mode: 'AUDIO',
+          offer: null,
+        }
+      );
+    });
+
+    await act(async () => {
+      await ctxRef.acceptCall();
+    });
+
+    const answerCall =
+      fetchMock.mock.calls.find(
+        ([url]) =>
+          url.includes(
+            '/calls/answer'
+          )
+      );
+
+    expect(answerCall)
+      .toBeTruthy();
+
+    expect(
+      JSON.parse(
+        answerCall[1].body
+      )
+    ).toEqual({
+      callId:
+        'incoming-audio-1',
+      answer: null,
+    });
+
+    expect(
+      mockInitializeVoice
+    ).toHaveBeenCalled();
+
+    expect(
+      mockAcceptIncomingVoiceCall
+    ).toHaveBeenCalledTimes(1);
+
+    expect(
+      navigator.mediaDevices
+        .getUserMedia
+    ).not.toHaveBeenCalled();
+
+    expect(
+      fetchMock.mock.calls.some(
+        ([url]) =>
+          url.includes(
+            '/ice-servers'
+          )
+      )
+    ).toBe(false);
+
+    expect(
+      ctxRef.active
+    ).toMatchObject({
+      callId:
+        'incoming-audio-1',
+      peerId: 456,
+      mode: 'AUDIO',
+      peerName: 'Reviewer',
+      mediaTransport:
+        'twilio-voice',
+    });
+
+    expect(
+      ctxRef.incoming
+    ).toBe(null);
+  }
+);
+
+test(
+  'acceptCall ends a claimed audio call when its Twilio invitation cannot connect',
+  async () => {
+    mockAcceptIncomingVoiceCall
+      .mockRejectedValueOnce(
+        new Error(
+          'Voice invitation unavailable'
+        )
+      );
+
+    renderWithProvider();
+
+    act(() => {
+      socketMock.emit(
+        'call:incoming',
+        {
+          callId:
+            'incoming-audio-2',
+          fromUser: {
+            id: 456,
+          },
+          mode: 'AUDIO',
+          offer: null,
+        }
+      );
+    });
+
+    let caughtError = null;
+
+    await act(async () => {
+      try {
+        await ctxRef.acceptCall();
+      } catch (error) {
+        caughtError = error;
+      }
+    });
+
+    expect(
+      caughtError?.message
+    ).toBe(
+      'Voice invitation unavailable'
+    );
+
+    const endCall =
+      fetchMock.mock.calls.find(
+        ([url]) =>
+          url.includes('/calls/end')
+      );
+
+    expect(endCall)
+      .toBeTruthy();
+
+    expect(
+      JSON.parse(
+        endCall[1].body
+      )
+    ).toEqual({
+      callId:
+        'incoming-audio-2',
+      reason:
+        'media_connect_failed',
+    });
+
+    expect(
+      ctxRef.active
+    ).toBe(null);
+  }
+);
+
+test(
+  'rejectCall rejects the canonical Twilio Voice invitation',
+  async () => {
+    renderWithProvider();
+
+    act(() => {
+      socketMock.emit(
+        'call:incoming',
+        {
+          callId:
+            'incoming-audio-3',
+          fromUser: {
+            id: 456,
+          },
+          mode: 'AUDIO',
+          offer: null,
+        }
+      );
+    });
+
+    await act(async () => {
+      await ctxRef.rejectCall();
+    });
+
+    expect(
+      mockRejectIncomingVoiceCall
+    ).toHaveBeenCalledTimes(1);
+
+    const endCall =
+      fetchMock.mock.calls.find(
+        ([url]) =>
+          url.includes('/calls/end')
+      );
+
+    expect(endCall)
+      .toBeTruthy();
+
+    expect(
+      JSON.parse(
+        endCall[1].body
+      )
+    ).toEqual({
+      callId:
+        'incoming-audio-3',
+      reason: 'rejected',
+    });
+
+    expect(
+      ctxRef.incoming
+    ).toBe(null);
+  }
+);
 
 test(
   'acceptCall claims and joins an incoming canonical Twilio Video room',

--- a/client/src/hooks/__tests__/useTwilioVoice.test.js
+++ b/client/src/hooks/__tests__/useTwilioVoice.test.js
@@ -176,4 +176,92 @@ describe('useTwilioVoice token refresh', () => {
     expect(device.destroy).toHaveBeenCalledTimes(1);
     expect(device.updateToken).not.toHaveBeenCalled();
   });
+  it('accepts an incoming Twilio Voice SDK invitation', async () => {
+    fetchVoiceToken.mockResolvedValueOnce({
+      token: 'incoming-token',
+      identity: 'user_1',
+    });
+
+    const { result, unmount } =
+      renderHook(() =>
+        useTwilioVoice()
+      );
+
+    await act(async () => {
+      await result.current.initialize();
+    });
+
+    const incomingCall = {
+      parameters: {
+        From: 'client:user_24',
+      },
+      on: jest.fn(),
+      accept: jest.fn(),
+      reject: jest.fn(),
+      disconnect: jest.fn(),
+    };
+
+    act(() => {
+      mockDevices[0].emit(
+        'incoming',
+        incomingCall
+      );
+    });
+
+    await act(async () => {
+      await result.current
+        .acceptIncomingCall();
+    });
+
+    expect(
+      incomingCall.accept
+    ).toHaveBeenCalledTimes(1);
+
+    unmount();
+  });
+
+  it('rejects an incoming Twilio Voice SDK invitation', async () => {
+    fetchVoiceToken.mockResolvedValueOnce({
+      token: 'incoming-token',
+      identity: 'user_1',
+    });
+
+    const { result, unmount } =
+      renderHook(() =>
+        useTwilioVoice()
+      );
+
+    await act(async () => {
+      await result.current.initialize();
+    });
+
+    const incomingCall = {
+      parameters: {
+        From: 'client:user_24',
+      },
+      on: jest.fn(),
+      accept: jest.fn(),
+      reject: jest.fn(),
+      disconnect: jest.fn(),
+    };
+
+    act(() => {
+      mockDevices[0].emit(
+        'incoming',
+        incomingCall
+      );
+    });
+
+    await act(async () => {
+      await result.current
+        .rejectIncomingCall();
+    });
+
+    expect(
+      incomingCall.reject
+    ).toHaveBeenCalledTimes(1);
+
+    unmount();
+  });
+
 });

--- a/client/src/hooks/useTwilioVoice.js
+++ b/client/src/hooks/useTwilioVoice.js
@@ -7,6 +7,7 @@ export function useTwilioVoice() {
   const deviceRef = useRef(null);
   const tokenRef = useRef(null);
   const tokenRefreshPromiseRef = useRef(null);
+  const currentCallRef = useRef(null);
 
   const [ready, setReady] = useState(false);
   const [initializing, setInitializing] = useState(false);
@@ -17,6 +18,7 @@ export function useTwilioVoice() {
 
   const clearCallState = useCallback(() => {
     setCalling(false);
+    currentCallRef.current = null;
     setCurrentCall(null);
     setCallStatus('idle');
   }, []);
@@ -26,6 +28,7 @@ export function useTwilioVoice() {
 
     call.on('accept', () => {
       setCalling(false);
+      currentCallRef.current = call;
       setCurrentCall(call);
       setCallStatus('in-call');
       console.log('[twilio] Call accepted');
@@ -33,6 +36,7 @@ export function useTwilioVoice() {
 
     call.on('disconnect', () => {
       setCalling(false);
+      currentCallRef.current = null;
       setCurrentCall(null);
       setCallStatus('ended');
       console.log('[twilio] Call disconnected');
@@ -44,6 +48,7 @@ export function useTwilioVoice() {
 
     call.on('cancel', () => {
       setCalling(false);
+      currentCallRef.current = null;
       setCurrentCall(null);
       setCallStatus('ended');
       console.log('[twilio] Call cancelled');
@@ -55,6 +60,7 @@ export function useTwilioVoice() {
 
     call.on('reject', () => {
       setCalling(false);
+      currentCallRef.current = null;
       setCurrentCall(null);
       setCallStatus('ended');
       console.log('[twilio] Call rejected');
@@ -68,6 +74,7 @@ export function useTwilioVoice() {
       const msg = err?.message || 'Twilio call error';
       setError(msg);
       setCalling(false);
+      currentCallRef.current = null;
       setCurrentCall(null);
       setCallStatus('error');
       toast.err?.(msg);
@@ -155,6 +162,7 @@ export function useTwilioVoice() {
 
       device.on('incoming', (call) => {
         console.log('[twilio] Incoming call from', call.parameters?.From);
+        currentCallRef.current = call;
         setCurrentCall(call);
         setCallStatus('incoming');
         attachCallListeners(call);
@@ -225,6 +233,8 @@ export function useTwilioVoice() {
           params,
         });
 
+        currentCallRef.current = call;
+
         setCurrentCall(call);
         setCallStatus('ringing');
         attachCallListeners(call);
@@ -249,12 +259,124 @@ export function useTwilioVoice() {
     [attachCallListeners, initDevice]
   );
 
+  const waitForIncomingCall =
+    useCallback(
+      async (
+        timeoutMs = 10000
+      ) => {
+        const deadline =
+          Date.now() + timeoutMs;
+
+        while (
+          !currentCallRef.current &&
+          Date.now() < deadline
+        ) {
+          await new Promise(
+            (resolve) =>
+              setTimeout(resolve, 50)
+          );
+        }
+
+        const call =
+          currentCallRef.current;
+
+        if (!call) {
+          throw new Error(
+            'The incoming voice connection did not arrive.'
+          );
+        }
+
+        return call;
+      },
+      []
+    );
+
+  const acceptIncomingCall =
+    useCallback(
+      async () => {
+        try {
+          setCalling(true);
+          setError(null);
+          setCallStatus(
+            'connecting'
+          );
+
+          const call =
+            await waitForIncomingCall();
+
+          if (
+            typeof call.accept !==
+            'function'
+          ) {
+            throw new Error(
+              'The incoming voice connection cannot be answered.'
+            );
+          }
+
+          call.accept();
+          return call;
+        } catch (e) {
+          const msg =
+            e?.message ||
+            'Failed to answer incoming voice call';
+
+          setError(msg);
+          setCalling(false);
+          setCallStatus('error');
+          toast.err?.(msg);
+          throw e;
+        }
+      },
+      [waitForIncomingCall]
+    );
+
+  const rejectIncomingCall =
+    useCallback(() => {
+      const call =
+        currentCallRef.current;
+
+      if (!call) return;
+
+      try {
+        if (
+          typeof call.reject ===
+          'function'
+        ) {
+          call.reject();
+        } else if (
+          typeof call.disconnect ===
+          'function'
+        ) {
+          call.disconnect();
+        }
+      } catch (e) {
+        console.error(
+          '[twilio] reject error',
+          e
+        );
+      } finally {
+        clearCallState();
+      }
+    }, [clearCallState]);
+
   const hangup = useCallback(() => {
     try {
       setCallStatus('ending');
 
-      if (currentCall) {
-        currentCall.disconnect();
+      const call =
+        currentCallRef.current ||
+        currentCall;
+
+      if (call) {
+        if (
+          callStatus === 'incoming' &&
+          typeof call.reject ===
+            'function'
+        ) {
+          call.reject();
+        } else {
+          call.disconnect();
+        }
       } else if (deviceRef.current) {
         deviceRef.current.disconnectAll();
       }
@@ -263,7 +385,11 @@ export function useTwilioVoice() {
     } finally {
       clearCallState();
     }
-  }, [clearCallState, currentCall]);
+  }, [
+    callStatus,
+    clearCallState,
+    currentCall,
+  ]);
 
   useEffect(() => {
     return () => {
@@ -277,6 +403,7 @@ export function useTwilioVoice() {
         deviceRef.current = null;
         tokenRef.current = null;
         tokenRefreshPromiseRef.current = null;
+        currentCallRef.current = null;
       }
     };
   }, []);
@@ -288,7 +415,10 @@ export function useTwilioVoice() {
     callStatus,
     error,
     currentCall,
+    initialize: initDevice,
     startBrowserCall,
+    acceptIncomingCall,
+    rejectIncomingCall,
     hangup,
   };
 }


### PR DESCRIPTION
## Summary

* Register the browser Twilio Voice device so it can receive native app audio-call invitations.
* Route canonical incoming audio calls without SDP offers through Twilio Voice instead of legacy WebRTC.
* Claim the backend call before accepting the corresponding Twilio Voice invitation.
* Support accepting and rejecting incoming Twilio Voice SDK calls.
* End already-claimed calls with `media_connect_failed` when media acceptance fails.
* Preserve the existing legacy SDP/WebRTC and participant-call paths.
* Add regression coverage for incoming audio acceptance, failure reconciliation, and rejection.

## Root cause

Native iOS and Android audio calls arrive at the website as canonical Twilio Voice calls with no SDP offer. The website incorrectly sent these calls through its legacy WebRTC acceptance path, which requested ICE servers and attempted to use a missing SDP offer. The browser Twilio Voice device also was not initialized until an outgoing call began.

## Verification

* Incoming-audio, Twilio Voice, call-context, modal, and call-screen focused suites passed: 32/32 tests.
* Full client test suite passed: 538/538 tests.
* Production Vite build passed.
* `git diff --check` and staged diff checks passed.
* Physical app-to-website audio-call verification remains pending production deployment.
