### PR TITLE
Route placeholder SDP calls through Twilio

### DIFF
--- a/client/src/context/CallContext.jsx
+++ b/client/src/context/CallContext.jsx
@@ -7,6 +7,23 @@ import { joinRoom } from '@/video/video';
 const CallCtx = createContext(null);
 export const useCall = () => useContext(CallCtx);
 
+function hasUsableLegacyOffer(offer) {
+  const type =
+    String(offer?.type || '')
+      .trim()
+      .toLowerCase();
+
+  const sdp =
+    typeof offer?.sdp === 'string'
+      ? offer.sdp.trimStart()
+      : '';
+
+  return (
+    type === 'offer' &&
+    /^v=0(?:\r?\n|$)/.test(sdp)
+  );
+}
+
 /**
  * Server payloads (for reference):
  * - /ice-servers?provider=all -> { iceServers: [...] }
@@ -708,6 +725,9 @@ return data;
 
     const { callId, fromUser, offer, mode = 'AUDIO' } = incoming;
 
+    const hasLegacyOffer =
+      hasUsableLegacyOffer(offer);
+
     const peerName =
       incoming.callerName ||
       fromUser?.displayName ||
@@ -769,7 +789,7 @@ return data;
      */
     if (
       mode === 'AUDIO' &&
-      !offer
+      !hasLegacyOffer
     ) {
       answeringCallIdRef.current =
         callId;
@@ -903,7 +923,7 @@ return data;
      */
     if (
       mode === 'VIDEO' &&
-      !offer
+      !hasLegacyOffer
     ) {
       const roomName =
         incoming.roomName ||
@@ -1195,7 +1215,9 @@ async function onParticipantOffer({ callId, fromUser, offer }) {
       !incoming.isParticipantInvite &&
       incoming.mode?.toUpperCase() ===
         'AUDIO' &&
-      !incoming.offer;
+      !hasUsableLegacyOffer(
+        incoming.offer
+      );
 
     if (rejectsTwilioVoice) {
       twilioVoice

--- a/client/src/context/__tests__/CallContext.test.js
+++ b/client/src/context/__tests__/CallContext.test.js
@@ -360,7 +360,7 @@ id: 101,
 mode: 'VIDEO',
 offer: {
 type: 'offer',
-sdp: 'incoming-offer',
+sdp: 'v=0\r\n',
 },
 });
 });
@@ -403,7 +403,7 @@ id: 5,
 mode: 'VIDEO',
 offer: {
 type: 'offer',
-sdp: 'incoming-offer',
+sdp: 'v=0\r\n',
 },
 });
 });
@@ -542,7 +542,7 @@ test('startCall routes app audio through Twilio Voice with the backend call ID',
 });
 
 test(
-  'acceptCall claims and accepts an incoming canonical Twilio Voice call',
+  'acceptCall routes a placeholder SDP offer through Twilio Voice',
   async () => {
     renderWithProvider();
 
@@ -558,7 +558,10 @@ test(
               'Reviewer',
           },
           mode: 'AUDIO',
-          offer: null,
+          offer: {
+            type: 'offer',
+            sdp: 'placeholder',
+          },
         }
       );
     });
@@ -698,7 +701,7 @@ test(
 );
 
 test(
-  'rejectCall rejects the canonical Twilio Voice invitation',
+  'rejectCall rejects Twilio Voice when the SDP offer is a placeholder',
   async () => {
     renderWithProvider();
 
@@ -712,7 +715,10 @@ test(
             id: 456,
           },
           mode: 'AUDIO',
-          offer: null,
+          offer: {
+            type: 'offer',
+            sdp: 'placeholder',
+          },
         }
       );
     });
@@ -914,7 +920,7 @@ test('acceptCall consumes incoming offer, sends answer, sets active and clears i
       mode: 'AUDIO',
       offer: {
         type: 'offer',
-        sdp: 'incoming-offer',
+        sdp: 'v=0\r\n',
       },
     };
 
@@ -1160,7 +1166,7 @@ test(
         mode: 'AUDIO',
         offer: {
           type: 'offer',
-          sdp: 'incoming-offer',
+          sdp: 'v=0\r\n',
         },
       });
     });
@@ -1238,7 +1244,7 @@ test(
         mode: 'VIDEO',
         offer: {
           type: 'offer',
-          sdp: 'incoming-offer',
+          sdp: 'v=0\r\n',
         },
       });
     });


### PR DESCRIPTION
## Summary

* Detect genuine legacy WebRTC offers by requiring an SDP offer beginning with `v=0`.
* Route native-app placeholder offers through the registered Twilio Voice device.
* Apply the same SDP validation to audio rejection and canonical video routing.
* Preserve the existing legacy WebRTC path for genuine browser SDP offers.
* Add regression coverage for accepting and rejecting placeholder audio offers.
* Update legacy WebRTC fixtures to use minimally valid SDP.

## Root cause

Native iOS audio calls send an offer object whose SDP is `placeholder`. The website treated every existing offer object as legacy WebRTC and attempted `setRemoteDescription()` with that placeholder, producing an SDP parsing failure and incorrectly requesting `/ice-servers`.

## Verification

* CallContext suite passed: 18/18 tests.
* Related call suites passed: 32/32 tests.
* Production Vite build passed.
* `git diff --check` passed.
* Physical app-to-website audio verification remains pending deployment.
