### PR TITLE
Route Twilio Voice calls to web clients

### DIFF
--- a/server/__tests__/voiceDeviceService.test.js
+++ b/server/__tests__/voiceDeviceService.test.js
@@ -22,6 +22,12 @@ const {
   '../services/voiceDeviceService.js'
 );
 
+const {
+  parseVoiceIdentityUserId,
+} = await import(
+  '../utils/voiceIdentity.js'
+);
+
 describe('voiceDeviceService', () => {
   beforeEach(() => {
     prismaDeviceFindMany.mockReset();
@@ -208,6 +214,12 @@ describe('voiceDeviceService', () => {
         platform: 'ios',
         legacy: false,
       },
+      {
+        identity: 'user:42',
+        deviceId: null,
+        platform: 'web',
+        legacy: false,
+      },
     ]);
   });
 
@@ -218,6 +230,12 @@ describe('voiceDeviceService', () => {
       await getVoiceDialDestinations(42);
 
     expect(destinations).toEqual([
+      {
+        identity: 'user:42',
+        deviceId: null,
+        platform: 'web',
+        legacy: false,
+      },
       {
         identity: 'user_42',
         deviceId: null,
@@ -238,8 +256,26 @@ describe('voiceDeviceService', () => {
         }
       );
 
-    expect(destinations).toEqual([]);
+    expect(destinations).toEqual([
+      {
+        identity: 'user:42',
+        deviceId: null,
+        platform: 'web',
+        legacy: false,
+      },
+    ]);
   });
+
+  test(
+    'parses the browser Voice identity',
+    () => {
+      expect(
+        parseVoiceIdentityUserId(
+          'client:user:42'
+        )
+      ).toBe(42);
+    }
+  );
 
   test('never returns more than 10 eligible devices', async () => {
     prismaDeviceFindMany.mockResolvedValue(

--- a/server/__tests__/voiceWebhooks.test.js
+++ b/server/__tests__/voiceWebhooks.test.js
@@ -496,7 +496,7 @@ describe('POST /webhooks/voice/inbound', () => {
 // -----------------------------------------------------------------------------
 
 describe('POST /webhooks/voice/client app-to-app voicemail handoff', () => {
-  it('fans out one Dial to all registered Voice devices and parses a device-specific caller identity', async () => {
+  it('fans out one Dial to mobile devices and the browser while parsing a device-specific caller identity', async () => {
     prisma.user.findUnique
       .mockResolvedValueOnce({
         id: 99,
@@ -520,6 +520,12 @@ describe('POST /webhooks/voice/client app-to-app voicemail handoff', () => {
           'user_99_device_ios_device_456',
         deviceId: 'ios-device-456',
         platform: 'ios',
+        legacy: false,
+      },
+      {
+        identity: 'user:99',
+        deviceId: null,
+        platform: 'web',
         legacy: false,
       },
     ]);
@@ -557,13 +563,14 @@ describe('POST /webhooks/voice/client app-to-app voicemail handoff', () => {
       method: 'POST',
     });
 
-    expect(actions[0].clients).toHaveLength(2);
+    expect(actions[0].clients).toHaveLength(3);
 
     expect(
       actions[0].clients.map((client) => client.to)
     ).toEqual([
       'user_99_device_android_device_123',
       'user_99_device_ios_device_456',
+      'user:99',
     ]);
 
     for (const client of actions[0].clients) {

--- a/server/routes/voice.js
+++ b/server/routes/voice.js
@@ -4,6 +4,9 @@ import { requireAuth } from '../middleware/auth.js';
 import { asyncHandler } from '../utils/asyncHandler.js';
 import { startAliasCall } from '../services/voiceBridge.js';
 import logger from '../utils/logger.js';
+import {
+  buildBrowserVoiceIdentity,
+} from '../utils/voiceIdentity.js';
 
 const r = express.Router();
 
@@ -35,7 +38,10 @@ r.post(
       });
     }
 
-    const identity = `user:${req.user.id}`;
+    const identity =
+      buildBrowserVoiceIdentity(
+        req.user.id
+      );
     const ttlSeconds = 3600;
 
     const token = new AccessToken(

--- a/server/services/voiceDeviceService.js
+++ b/server/services/voiceDeviceService.js
@@ -1,5 +1,6 @@
 import prisma from '../utils/prismaClient.js';
 import {
+  buildBrowserVoiceIdentity,
   buildDeviceVoiceIdentity,
   buildLegacyVoiceIdentity,
   MAX_VOICE_FANOUT_DEVICES,
@@ -165,31 +166,55 @@ export async function getVoiceDialDestinations(
       Boolean(destination.identity)
     );
 
-  if (deviceDestinations.length > 0) {
-    return deviceDestinations;
+  /*
+   * Reserve one Twilio fan-out destination for the website.
+   * Browser Voice tokens use a distinct identity so web calls
+   * do not weaken device-specific mobile authorization.
+   */
+  const destinations =
+    deviceDestinations.slice(
+      0,
+      MAX_VOICE_FANOUT_DEVICES - 1
+    );
+
+  const browserIdentity =
+    buildBrowserVoiceIdentity(
+      numericUserId
+    );
+
+  if (browserIdentity) {
+    destinations.push({
+      identity: browserIdentity,
+      deviceId: null,
+      platform: 'web',
+      legacy: false,
+    });
   }
 
   /*
    * Temporary migration compatibility only.
    *
-   * Remove this fallback after supported Android/iOS versions
-   * reliably confirm device-specific Voice registration.
+   * Preserve the legacy mobile identity only when no confirmed
+   * device-specific mobile registration exists.
    */
-  if (!allowLegacyFallback) {
-    return [];
+  if (
+    deviceDestinations.length === 0 &&
+    allowLegacyFallback
+  ) {
+    const legacyIdentity =
+      buildLegacyVoiceIdentity(
+        numericUserId
+      );
+
+    if (legacyIdentity) {
+      destinations.push({
+        identity: legacyIdentity,
+        deviceId: null,
+        platform: null,
+        legacy: true,
+      });
+    }
   }
 
-  const legacyIdentity =
-    buildLegacyVoiceIdentity(numericUserId);
-
-  return legacyIdentity
-    ? [
-        {
-          identity: legacyIdentity,
-          deviceId: null,
-          platform: null,
-          legacy: true,
-        },
-      ]
-    : [];
+  return destinations;
 }

--- a/server/utils/voiceIdentity.js
+++ b/server/utils/voiceIdentity.js
@@ -58,10 +58,43 @@ export function buildLegacyVoiceIdentity(userId) {
   return `user_${numericUserId}`;
 }
 
+export function buildBrowserVoiceIdentity(userId) {
+  const numericUserId = Number(userId);
+
+  if (
+    !Number.isInteger(numericUserId) ||
+    numericUserId <= 0
+  ) {
+    return null;
+  }
+
+  return `user:${numericUserId}`;
+}
+
 export function parseVoiceIdentity(identity) {
   const raw = String(identity || '')
     .trim()
     .replace(/^client:/, '');
+
+  const browserMatch =
+    raw.match(/^user:(\d+)$/);
+
+  if (browserMatch) {
+    const userId =
+      Number(browserMatch[1]);
+
+    if (
+      Number.isInteger(userId) &&
+      userId > 0
+    ) {
+      return {
+        identity: raw,
+        userId,
+        deviceSpecific: false,
+        deviceIdentityPart: null,
+      };
+    }
+  }
 
   const match = raw.match(
     /^user_(\d+)(?:_device_(.+))?$/


### PR DESCRIPTION
## Summary

* Add a canonical Twilio Voice identity for authenticated website clients.
* Include the website identity in app-to-app Voice fan-out alongside authorized iOS and Android device identities.
* Preserve device-specific mobile authorization and the temporary legacy fallback behavior.
* Keep the total Twilio dial fan-out within the existing ten-destination limit.
* Parse website Voice identities so browser-originated calls retain the correct user identity.
* Add focused regression coverage for browser identity parsing and mobile-plus-web call fan-out.

## Root cause

The website registered its Twilio Voice Device with an identity such as `user:1`, while the server dialed only device-specific identities such as `user_1_device_...` or the legacy identity `user_1`.

Twilio identities must match exactly. Consequently, Twilio successfully fetched the call instructions, but the registered website client never received the SDK `incoming` event. The website then timed out with “The incoming voice connection did not arrive.”

## Verification

* JavaScript syntax checks passed for the modified route, identity utility, and destination service.
* Focused Voice destination and webhook suites passed: 35/35 tests.
* Complete server suite passed: 215/215 suites and 1,379/1,379 tests.
* `git diff --check` and staged diff checks passed.
* Physical app-to-website audio-call verification remains pending production deployment.
